### PR TITLE
[kafka-connect-druid] now compiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ target/
 /kafka-connect-cassandra/docs/build
 /.gradle
 /rethinkdb_data/
+/.ensime
+/.ensime_cache.d/

--- a/kafka-connect-druid/build.gradle
+++ b/kafka-connect-druid/build.gradle
@@ -9,9 +9,9 @@ project(":kafka-connect-druid") {
     }
 
     dependencies {
+        compile "com.github.nscala-time:nscala-time_$scalaMajorVersion:2.12.0"
         compile "com.datamountaineer:kafka-connect-common:$dataMountaineerCommonVersion"
         compile "io.druid:tranquility-core_$scalaMajorVersion:$tranquilityCoreVersion"
         testCompile("org.kitesdk:kite-minicluster:$kiteMiniClusterVersion")
-        testCompile("org.apache.hbase:hbase-server:$hbaseServerVersion")
     }
 }

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/DruidSinkConnector.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/DruidSinkConnector.scala
@@ -17,6 +17,12 @@
 package com.datamountaineer.streamreactor.connect.druid
 
 import java.util
+import scala.collection.JavaConverters._
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import io.confluent.common.config.ConfigDef
+import org.apache.kafka.connect.connector.Task
+import org.apache.kafka.connect.sink.SinkConnector
+import com.datamountaineer.streamreactor.connect.druid.config._
 
 /**
   *

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/DruidSinkTask.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/DruidSinkTask.scala
@@ -17,6 +17,13 @@
 package com.datamountaineer.streamreactor.connect.druid
 
 import java.util
+import scala.collection.JavaConversions._
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.connect.sink.{ SinkTask, SinkRecord }
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import org.apache.kafka.common.TopicPartition
+import com.datamountaineer.streamreactor.connect.druid.writer.DruidDbWriter
+import com.datamountaineer.streamreactor.connect.druid.config._
 
 /**
   * Created by andrew@datamountaineer.com on 04/03/16. 

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkConfig.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkConfig.scala
@@ -17,7 +17,8 @@
 package com.datamountaineer.streamreactor.connect.druid.config
 
 import java.util
-
+import io.confluent.common.config.{ ConfigDef, AbstractConfig }
+import ConfigDef.{ Type, Importance }
 
 object DruidSinkConfig {
   val DATASOURCE_NAME = "connect.druid.sink.datasource.name"

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkSettings.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkSettings.scala
@@ -17,6 +17,10 @@
 package com.datamountaineer.streamreactor.connect.druid.config
 
 import java.io.File
+import scala.util.Try
+import io.confluent.common.config.ConfigException
+import com.datamountaineer.streamreactor.connect.schemas.PayloadFields
+import DruidSinkConfig._
 
 case class DruidSinkSettings(datasourceName: String,
                              tranquilityConfig: String,

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/writer/DruidDbWriter.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/writer/DruidDbWriter.scala
@@ -17,6 +17,17 @@
 package com.datamountaineer.streamreactor.connect.druid.writer
 
 import java.io.ByteArrayInputStream
+import collection.JavaConversions._
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.twitter.util.{ Future, Await }
+import com.github.nscala_time.time.Imports._
+import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.sink.SinkRecord
+import com.datamountaineer.streamreactor.connect.schemas.StructFieldsExtractor
+import com.datamountaineer.streamreactor.connect.sink.DbWriter
+import com.metamx.tranquility.config.{ TranquilityConfig, PropertiesBasedConfig }
+import com.metamx.tranquility.druid.DruidBeams
+import com.datamountaineer.streamreactor.connect.druid.config.DruidSinkSettings
 
 /**
   * Responsible for writing the SinkRecord payload to Druid.

--- a/kafka-connect-druid/src/test/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkSettingsTest.scala
+++ b/kafka-connect-druid/src/test/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkSettingsTest.scala
@@ -1,6 +1,11 @@
 package com.datamountaineer.streamreactor.connect.druid.config
 
 import java.nio.file.Paths
+import scala.collection.JavaConversions._
+import org.scalatest._
+import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito._
+import io.confluent.common.config.ConfigException
 
 class DruidSinkSettingsTest extends WordSpec with Matchers with MockitoSugar {
   "DruidSinkSettings" should {

--- a/kafka-connect-druid/src/test/scala/com/datamountaineer/streamreactor/connect/druid/writer/WikipediaSchemaBuilderFn.scala
+++ b/kafka-connect-druid/src/test/scala/com/datamountaineer/streamreactor/connect/druid/writer/WikipediaSchemaBuilderFn.scala
@@ -1,5 +1,7 @@
 package com.datamountaineer.streamreactor.connect.druid.writer
 
+import org.apache.kafka.connect.data.{ Schema, SchemaBuilder }
+
 object WikipediaSchemaBuilderFn {
   def apply(): Schema = {
     val schema = SchemaBuilder.struct().name("com.example.Wikipedia")


### PR DESCRIPTION
For some reasons, all the import statements not targeting java.* namespace had disappeared.

Are you open to contributions? This one is quite humble. Still we are a team in the UK planning to use Druid as a sink for some of our Kafka topics. We stumbled on this repo which looked like the best start to get going. Let me know your thoughts!