### PR TITLE
Merging yahoo & druid (#37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ target/
 /kafka-connect-cassandra/docs/build
 /.gradle
 /rethinkdb_data/
+/.ensime
+/.ensime_cache.d/

--- a/build.gradle
+++ b/build.gradle
@@ -46,12 +46,12 @@ allprojects {
         json4sVersion = "3.3.0"
         kiteMiniClusterVersion = "1.1.0"
         gsonVersion = "2.6.2"
-        dataMountaineerCQLVersion = "0.3.1"
+        dataMountaineerCQLVersion = "0.4"
         confluentVersion = '2.0.1'
     }
 
     repositories {
-        //mavenLocal()
+        mavenLocal()
         mavenCentral()
         maven { url "http://packages.confluent.io/maven/" }
         maven { url "http://repo.typesafe.com/typesafe/releases/" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 21 13:51:46 CEST 2016
+#Fri Jul 08 11:34:32 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip

--- a/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergFieldValueFn.scala
+++ b/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergFieldValueFn.scala
@@ -60,7 +60,7 @@ private[bloomberg] object BloombergFieldValueFn {
         offsetDateTime(dt)
 
       case 258 | 259 /*Schema.Datatype.SEQUENCE | Schema.Datatype.CHOICE*/ =>
-        element.elementIterator().asScala.foldLeft(new java.util.LinkedHashMap[String, Any]) { case (map, element) =>
+        element.elementIterator().asScala.foldLeft(new java.util.LinkedHashMap[String, Any]) { case (map, `element`) =>
           map.put(element.name().toString, BloombergFieldValueFn(element))
           map
         } //needs to be a java map because of json serialization

--- a/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergSourceTask.scala
+++ b/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergSourceTask.scala
@@ -112,7 +112,7 @@ class BloombergSourceTask extends SourceTask with StrictLogging {
     * @return A list of records as a result of Bloomberg updates since the previous call.
     */
   override def poll(): util.List[SourceRecord] = {
-    subscriptionManager.get.getData.map { case d =>
+    subscriptionManager.get.getData.map { d =>
       val list = new util.ArrayList[SourceRecord](d.size())
       d.asScala.foreach { d =>
         list.add(d.toSourceRecord(settings.get))

--- a/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/ConnectSchema.scala
+++ b/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/ConnectSchema.scala
@@ -49,9 +49,8 @@ private[bloomberg] class ConnectSchema(namespace: String) {
       case map: java.util.LinkedHashMap[String @unchecked, _] =>
         val recordBuilder = SchemaBuilder.struct()
         recordBuilder.name(name)
-        map.entrySet().asScala.foreach { case kvp =>
-          recordBuilder.field(kvp.getKey, createSchema(kvp.getKey, kvp.getValue))
-        }
+        map.entrySet().asScala.foreach(kvp =>
+          recordBuilder.field(kvp.getKey, createSchema(kvp.getKey, kvp.getValue)))
         recordBuilder.build()
       case v => sys.error(s"${v.getClass} is not handled.")
     }

--- a/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/SubscriptionInfo.scala
+++ b/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/SubscriptionInfo.scala
@@ -34,7 +34,7 @@ case class SubscriptionInfo(ticket: String, fields: Seq[String]) {
 object SubscriptionInfoExtractFn {
   def apply(source: String): Seq[SubscriptionInfo] = {
     require(source != null && source.trim.nonEmpty, "Invalid subscription setting.The format is <Ticker:Field1,Field2[;Ticker2:field1,field2;...]")
-    source.split(";").map { case subscription =>
+    source.split(";").map { subscription =>
       val index = subscription.indexOf(":")
       if (index < 0) {
         throw new IllegalArgumentException("Invalid configuration. Missing \":\". The format is <Ticker:Field1,Field2[;Ticker2:field1,field2;...]")

--- a/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/avro/AvroSchemaGenerator.scala
+++ b/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/avro/AvroSchemaGenerator.scala
@@ -58,7 +58,7 @@ private[bloomberg] class AvroSchemaGenerator(namespace: String) {
       case map: java.util.LinkedHashMap[String @unchecked, _] =>
         val record = Schema.createRecord(name, null, namespace, false)
         val fields = new java.util.ArrayList[Schema.Field](map.size())
-        map.entrySet().asScala.foreach { case kvp =>
+        map.entrySet().asScala.foreach { kvp =>
           val field = new Schema.Field(kvp.getKey, create(kvp.getKey, kvp.getValue, allowOptional = true), null, defaultValue)
           fields.add(field)
         }

--- a/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/avro/AvroSerializer.scala
+++ b/kafka-connect-bloomberg/src/main/scala/com/datamountaineer/streamreactor/connect/bloomberg/avro/AvroSerializer.scala
@@ -106,9 +106,8 @@ object AvroSerializer {
           val fieldSchema = schema.getField(fieldName).schema()
           val nestedSchema = if (fieldSchema.getType == Schema.Type.UNION) fieldSchema.getTypes.get(1) else fieldSchema
           val nestedRecord = new Record(nestedSchema)
-          map.entrySet().asScala.foreach { case e =>
-            recursive(nestedRecord, nestedSchema, e.getKey, e.getValue)
-          }
+          map.entrySet().asScala.foreach(e =>
+            recursive(nestedRecord, nestedSchema, e.getKey, e.getValue))
           record.put(fieldName, nestedRecord)
       }
     }

--- a/kafka-connect-bloomberg/src/test/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergSubscriptionManagerTest.scala
+++ b/kafka-connect-bloomberg/src/test/scala/com/datamountaineer/streamreactor/connect/bloomberg/BloombergSubscriptionManagerTest.scala
@@ -31,7 +31,7 @@ class BloombergSubscriptionManagerTest extends WordSpec with Matchers with Mocki
         EventType.TOPIC_STATUS,
         EventType.TOKEN_STATUS)
 
-      events.map { case et =>
+      events.map { et =>
         val ev = mock[Event]
         when(ev.eventType()).thenReturn(et)
         when(ev.iterator()).thenReturn(Seq.empty[Message].iterator.asJava)

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/CassandraConnection.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/CassandraConnection.scala
@@ -23,7 +23,6 @@ import com.datastax.driver.core.policies.{DCAwareRoundRobinPolicy, TokenAwarePol
 import com.datastax.driver.core.{Cluster, JdkSSLOptions, QueryOptions, Session}
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.common.config.AbstractConfig
-import org.apache.kafka.connect.errors.ConnectException
 
 /**
   * Set up a Casssandra connection

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -18,8 +18,8 @@ package com.datamountaineer.streamreactor.connect.cassandra.config
 
 import java.util
 
-import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 import org.apache.kafka.common.config.ConfigDef.{Importance, Type}
+import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 
 /**
   *Holds the base configuration.

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -121,8 +121,8 @@ object CassandraConfigConstants {
 
 
   val EXPORT_ROUTE_QUERY = "connect.cassandra.export.route.query"
-  val EXPORT_ROUTE_QUERY_DOC = ""
+  val EXPORT_ROUTE_QUERY_DOC = "KCQL expression describing field selection and routes."
 
   val IMPORT_ROUTE_QUERY = "connect.cassandra.import.route.query"
-  val IMPORT_ROUTE_QUERY_DOC = ""
+  val IMPORT_ROUTE_QUERY_DOC = "KCQL expression describing field selection and routes."
 }

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/CassandraSinkConnector.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/CassandraSinkConnector.scala
@@ -23,7 +23,7 @@ import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.connector.{Connector, Task}
 import org.apache.kafka.connect.errors.ConnectException
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 import scala.util.{Failure, Try}
 
 /**
@@ -33,7 +33,7 @@ import scala.util.{Failure, Try}
   * Sets up CassandraSinkTask and configurations for the tasks.
   * */
 class CassandraSinkConnector extends Connector with StrictLogging {
-  private var configProps : util.Map[String, String] = null
+  private var configProps : util.Map[String, String] = _
 
   /**
     * States which SinkTask class to use
@@ -48,7 +48,7 @@ class CassandraSinkConnector extends Connector with StrictLogging {
     * */
   override def taskConfigs(maxTasks: Int): util.List[util.Map[String, String]] = {
     logger.info(s"Setting task configurations for $maxTasks workers.")
-    (1 to maxTasks).map(c=>configProps).toList.asJava
+    (1 to maxTasks).map(c => configProps).toList
   }
 
   /**

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/CassandraSinkTask.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/CassandraSinkTask.scala
@@ -22,71 +22,65 @@ import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfi
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.config.AbstractConfig
 import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTask}
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 import scala.util.{Failure, Success, Try}
 
 /**
   * <h1>CassandraSinkTask</h1>
   *
-  * Kafka Connect Cassandra sink task. Called by framework to put records to the
-  * target sink
-  * */
+  * Kafka Connect Cassandra sink task. Called by
+  * framework to put records to the target sink
+  **/
 class CassandraSinkTask extends SinkTask with StrictLogging {
-  private var writer : Option[CassandraJsonWriter] = None
+  private var writer: Option[CassandraJsonWriter] = None
   logger.info("Task initialising")
 
   /**
     * Parse the configurations and setup the writer
-    * */
+    **/
   override def start(props: util.Map[String, String]): Unit = {
     val taskConfig = Try(new CassandraConfigSink(props)) match {
       case Failure(f) => throw new ConnectException("Couldn't start CassandraSink due to configuration error.", f)
       case Success(s) => s
     }
 
-    logger.info("""
-               |    ____        __        __  ___                  __        _
-               |   / __ \____ _/ /_____ _/  |/  /___  __  ______  / /_____ _(_)___  ___  ___  _____
-               |  / / / / __ `/ __/ __ `/ /|_/ / __ \/ / / / __ \/ __/ __ `/ / __ \/ _ \/ _ \/ ___/
-               | / /_/ / /_/ / /_/ /_/ / /  / / /_/ / /_/ / / / / /_/ /_/ / / / / /  __/  __/ /
-               |/_____/\__,_/\__/\__,_/_/  /_/\____/\__,_/_/ /_/\__/\__,_/_/_/ /_/\___/\___/_/
-               |       ______                                __           _____ _       __
-               |      / ____/___ _______________ _____  ____/ /________ _/ ___/(_)___  / /__
-               |     / /   / __ `/ ___/ ___/ __ `/ __ \/ __  / ___/ __ `/\__ \/ / __ \/ //_/
-               |    / /___/ /_/ (__  |__  ) /_/ / / / / /_/ / /  / /_/ /___/ / / / / / ,<
-               |    \____/\__,_/____/____/\__,_/_/ /_/\__,_/_/   \__,_//____/_/_/ /_/_/|_|
-               |
-               | By Andrew Stevenson.""".stripMargin)
-
+    logger.info(
+      """
+        |    ____        __        __  ___                  __        _
+        |   / __ \____ _/ /_____ _/  |/  /___  __  ______  / /_____ _(_)___  ___  ___  _____
+        |  / / / / __ `/ __/ __ `/ /|_/ / __ \/ / / / __ \/ __/ __ `/ / __ \/ _ \/ _ \/ ___/
+        | / /_/ / /_/ / /_/ /_/ / /  / / /_/ / /_/ / / / / /_/ /_/ / / / / /  __/  __/ /
+        |/_____/\__,_/\__/\__,_/_/  /_/\____/\__,_/_/ /_/\__/\__,_/_/_/ /_/\___/\___/_/
+        |       ______                                __           _____ _       __
+        |      / ____/___ _______________ _____  ____/ /________ _/ ___/(_)___  / /__
+        |     / /   / __ `/ ___/ ___/ __ `/ __ \/ __  / ___/ __ `/\__ \/ / __ \/ //_/
+        |    / /___/ /_/ (__  |__  ) /_/ / / / / /_/ / /  / /_/ /___/ / / / / / ,<
+        |    \____/\__,_/____/____/\__,_/_/ /_/\__,_/_/   \__,_//____/_/_/ /_/_/|_|
+        |
+        | By Andrew Stevenson.""".stripMargin)
     writer = Some(CassandraWriter(connectorConfig = taskConfig, context = context))
   }
 
   /**
     * Pass the SinkRecords to the writer for Writing
-    * */
+    **/
   override def put(records: util.Collection[SinkRecord]): Unit = {
     require(writer.nonEmpty, "Writer is not set!")
-    writer.foreach(w => w.write(records.asScala.toSet))
+    writer.foreach(w => w.write(records.toVector))
   }
 
   /**
     * Clean up Cassandra connections
-    * */
+    **/
   override def stop(): Unit = {
     logger.info("Stopping Cassandra sink.")
     writer.foreach(w => w.close())
   }
 
-  override def flush(map: util.Map[TopicPartition, OffsetAndMetadata]) : Unit = {
-//    //while (writer.get.insertCount.get > 0) {
-//      logger.info("Waiting for writes to flush.")
-//      Thread.sleep(flushSleep)
-//    //}
-  }
+  override def flush(map: util.Map[TopicPartition, OffsetAndMetadata]): Unit = {}
 
   override def version(): String = "1"
 }

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraSourceConnector.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraSourceConnector.scala
@@ -25,6 +25,7 @@ import org.apache.kafka.connect.connector.Task
 import org.apache.kafka.connect.source.SourceConnector
 import org.apache.kafka.connect.util.ConnectorUtils
 
+import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
 /**
@@ -60,16 +61,16 @@ class CassandraSourceConnector extends SourceConnector with StrictLogging {
     val numGroups = Math.min(tables.size, maxTasks)
 
     logger.info(s"Setting task configurations for $numGroups workers.")
-    val groups = ConnectorUtils.groupPartitions(tables.asJava, maxTasks).asScala
+    val groups = ConnectorUtils.groupPartitions(tables, maxTasks)
 
     //setup the config for each task and set assigned tables
     groups
       .map(g=> {
         val taskConfigs = new java.util.HashMap[String,String]
-        taskConfigs.put(CassandraConfigConstants.ASSIGNED_TABLES, g.asScala.mkString(","))
+        taskConfigs.put(CassandraConfigConstants.ASSIGNED_TABLES, g.mkString(","))
         taskConfigs.putAll(configProps.get)
-        taskConfigs.asScala.toMap.asJava
-      }).asJava
+        taskConfigs.toMap.asJava
+      })
   }
 
   /**

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -32,7 +32,6 @@ import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.source.{SourceRecord, SourceTaskContext}
 
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters.{mapAsJavaMapConverter, seqAsJavaListConverter}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
@@ -71,7 +70,7 @@ class CassandraTableReader(private val session: Session,
   private def buildOffsetMap(context: SourceTaskContext) : Option[Date] = {
     val offsetStorageKey = CassandraConfigConstants.ASSIGNED_TABLES
     val tables = List(topic)
-    val recoveredOffsets = OffsetHandler.recoverOffsets(offsetStorageKey, tables.asJava, context)
+    val recoveredOffsets = OffsetHandler.recoverOffsets(offsetStorageKey, tables, context)
     val offset = OffsetHandler.recoverOffset[String](recoveredOffsets,offsetStorageKey, table, timestampCol)
     Some(dateFormatter.parse(offset.getOrElse(defaultTimestamp)))
   }
@@ -237,7 +236,7 @@ class CassandraTableReader(private val session: Session,
     logger.info(s"Storing offset $offset")
 
     //create source record
-    val record = new SourceRecord(partition, Map(timestampCol -> offset).asJava, topic, struct.schema(), struct)
+    val record = new SourceRecord(partition, Map(timestampCol -> offset), topic, struct.schema(), struct)
 
     //add to queue
     logger.debug(s"Attempting to put SourceRecord ${record.toString} on queue for $keySpace.$table.")

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtils.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtils.scala
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.errors.ConnectException
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 /**
   * Created by andrew@datamountaineer.com on 21/04/16.
@@ -44,9 +44,9 @@ object CassandraUtils {
     * @param keySpace The keyspace to look in for the tables
     * */
   def checkCassandraTables(cluster: Cluster, routes: Set[Config], keySpace: String) : Unit = {
-    val metaData = cluster.getMetadata.getKeyspace(keySpace).getTables.asScala
-    val tables: Set[String] = metaData.map(t=>t.getName).toSet
-    val topics = routes.map(rm=>rm.getTarget)
+    val metaData = cluster.getMetadata.getKeyspace(keySpace).getTables
+    val tables: Set[String] = metaData.map(t => t.getName).toSet
+    val topics = routes.map(rm => rm.getTarget)
 
     //check tables
     if (tables.isEmpty) throw new ConnectException(s"No tables found in Cassandra for keyspace $keySpace")
@@ -66,7 +66,7 @@ object CassandraUtils {
   def convert(row: Row) : Struct = {
     //TODO do we need to get the list of columns everytime?
 
-    val cols = row.getColumnDefinitions.asScala
+    val cols = row.getColumnDefinitions
     val connectSchema = convertToConnectSchema(cols.toList)
     val struct = new Struct(connectSchema)
 
@@ -119,7 +119,7 @@ object CassandraUtils {
     * */
   def convertToConnectSchema(cols: List[Definition]) : Schema = {
     val builder = SchemaBuilder.struct
-    cols.map(c=>builder.field(c.getName, typeMapToConnect(c)))
+    cols.map(c => builder.field(c.getName, typeMapToConnect(c)))
     builder.build()
   }
 

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestCassandraConnectionSecure.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestCassandraConnectionSecure.scala
@@ -1,7 +1,6 @@
 package com.datamountaineer.streamreactor.connect.cassandra
 
-import com.datamountaineer.streamreactor.connect.cassandra.config.{CassandraConfig, CassandraConfigSink, CassandraConfigSource}
-import org.apache.kafka.common.config.AbstractConfig
+import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigSink
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 
 /**

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
@@ -17,7 +17,6 @@ import org.apache.kafka.connect.source.SourceTaskContext
 import org.apache.kafka.connect.storage.OffsetStorageReader
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 import org.mockito.Mockito._
-import org.scalatest.BeforeAndAfter
 import org.scalatest.mock.MockitoSugar
 
 import scala.collection.JavaConverters._
@@ -252,7 +251,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
   }
 
   //generate some test records
-  def getTestRecords(table: String) : Set[SinkRecord]= {
+  def getTestRecords(table: String) : Seq[SinkRecord]= {
     val schema = createSchema
     val assignment: mutable.Set[TopicPartition] = getAssignment.asScala.filter(tp=>tp.topic().equals(table))
 
@@ -261,7 +260,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
         val record: Struct = createRecord(schema, a.topic() + "-" + a.partition() + "-" + i)
         new SinkRecord(a.topic(), a.partition(), Schema.STRING_SCHEMA, "key", schema, record, i)
       })
-    }).toSet
+    }).toSeq
   }
 
 
@@ -309,6 +308,6 @@ trait TestConfig extends StrictLogging with MockitoSugar {
   }
 
   def stopEmbeddedCassandra() = {
-    EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+    EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
   }
 }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSinkConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSinkConfig.scala
@@ -1,7 +1,6 @@
 package com.datamountaineer.streamreactor.connect.cassandra.config
 
 import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
-import org.apache.kafka.common.config.AbstractConfig
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 
 class TestCassandraSinkConfig extends WordSpec with BeforeAndAfter with Matchers with TestConfig {

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSinkSettings.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSinkSettings.scala
@@ -3,13 +3,10 @@ package com.datamountaineer.streamreactor.connect.cassandra.config
 import com.datamountaineer.connector.config.Config
 import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
 import com.datamountaineer.streamreactor.connect.errors.RetryErrorPolicy
-import org.apache.kafka.common.config.AbstractConfig
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
-
-import scala.collection.JavaConverters._
 
 /**
   * Created by andrew@datamountaineer.com on 28/04/16. 
@@ -26,11 +23,11 @@ class TestCassandraSinkSettings extends WordSpec with Matchers  with MockitoSuga
     val parsedConf: List[Config] = settings.routes.toList
     parsedConf.size shouldBe 2
 
-    parsedConf(0).getTarget shouldBe TABLE1
-    parsedConf(0).getSource shouldBe TOPIC1 //no table mapping provide so should be the table
+    parsedConf.head.getTarget shouldBe TABLE1
+    parsedConf.head.getSource shouldBe TOPIC1 //no table mapping provide so should be the table
     parsedConf(1).getTarget shouldBe TOPIC2
     parsedConf(1).getSource shouldBe TOPIC2
 
-    settings.errorPolicy.isInstanceOf[RetryErrorPolicy] shouldBe (true)
+    settings.errorPolicy.isInstanceOf[RetryErrorPolicy] shouldBe true
   }
 }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSourceSettings.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSourceSettings.scala
@@ -11,11 +11,11 @@ class TestCassandraSourceSettings extends WordSpec with Matchers with TestConfig
   "CassandraSettings should return setting for a source" in {
     val taskConfig  = CassandraConfigSource(getCassandraConfigSourcePropsBulk)
     val assigned = List(TABLE1, TABLE2)
-    val settings = CassandraSettings.configureSource(taskConfig, assigned).toList
+    val settings = CassandraSettings.configureSource(taskConfig).toList
     settings.size shouldBe 2
-    settings(0).routes.getSource shouldBe TABLE1
-    settings(0).routes.getTarget shouldBe TABLE1 //no table mapping provided so should be the table
-    settings(0).bulkImportMode shouldBe true
+    settings.head.routes.getSource shouldBe TABLE1
+    settings.head.routes.getTarget shouldBe TABLE1 //no table mapping provided so should be the table
+    settings.head.bulkImportMode shouldBe true
     settings(1).routes.getSource shouldBe TABLE2
     settings(1).routes.getTarget shouldBe TOPIC2
     settings(1).bulkImportMode shouldBe true

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriter.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriter.scala
@@ -2,8 +2,7 @@ package com.datamountaineer.streamreactor.connect.cassandra.sink
 
 import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
 import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigSink
-import org.apache.kafka.common.config.AbstractConfig
-import org.apache.kafka.connect.sink.{SinkRecord, SinkTaskContext}
+import org.apache.kafka.connect.sink.SinkTaskContext
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterFieldSelection.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterFieldSelection.scala
@@ -2,7 +2,6 @@ package com.datamountaineer.streamreactor.connect.cassandra.sink
 
 import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
 import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigSink
-import org.apache.kafka.common.config.AbstractConfig
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterNoop.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterNoop.scala
@@ -2,7 +2,6 @@ package com.datamountaineer.streamreactor.connect.cassandra.sink
 
 import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
 import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigSink
-import org.apache.kafka.common.config.AbstractConfig
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
@@ -17,7 +16,7 @@ class TestCassandraJsonWriterNoop extends WordSpec with Matchers with MockitoSug
     startEmbeddedCassandra()
   }
 
-  "Cassandra JsonWriter with Noop should throw Cassandra expection and keep going" in {
+  "Cassandra JsonWriter with Noop should throw Cassandra exception and keep going" in {
     val session = createTableAndKeySpace(secure = true, ssl = false)
     val context = mock[SinkTaskContext]
     val assignment = getAssignment

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterRetry.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriterRetry.scala
@@ -2,7 +2,6 @@ package com.datamountaineer.streamreactor.connect.cassandra.sink
 
 import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
 import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigSink
-import org.apache.kafka.common.config.AbstractConfig
 import org.apache.kafka.connect.errors.RetriableException
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.mockito.Mockito._

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraReaderIncr.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraReaderIncr.scala
@@ -39,7 +39,7 @@ class TestCassandraReaderIncr extends WordSpec with Matchers with BeforeAndAfter
 
     //queue for reader to put records in
     val queue = new LinkedBlockingQueue[SourceRecord](100)
-    val setting = CassandraSettings.configureSource(taskConfig, assigned).head
+    val setting = CassandraSettings.configureSource(taskConfig).head
     val reader = CassandraTableReader(session = session, setting = setting, context = taskContext, queue = queue)
     reader.read()
 

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceConnector.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceConnector.scala
@@ -2,7 +2,7 @@ package com.datamountaineer.streamreactor.connect.cassandra.source
 
 import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
 import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigConstants
-import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
+import org.scalatest.{Matchers, WordSpec}
 
 import scala.collection.JavaConverters._
 /**

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTask.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTask.scala
@@ -2,7 +2,6 @@ package com.datamountaineer.streamreactor.connect.cassandra.source
 
 
 import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
-import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigSource
 import com.datamountaineer.streamreactor.connect.schemas.ConverterUtil
 import com.fasterxml.jackson.databind.JsonNode
 import org.scalatest.mock.MockitoSugar

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/TestSchemaConverter.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/TestSchemaConverter.scala
@@ -5,11 +5,11 @@ import java.nio.ByteBuffer
 import java.util.UUID
 
 import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
-import com.datastax.driver.core.{ColumnDefinitions, Row, TestUtils, TupleValue}
+import com.datastax.driver.core.{ColumnDefinitions, Row, TestUtils}
 import org.apache.kafka.connect.data.{Schema, Struct}
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
-import org.mockito.Mockito._
 
 import scala.collection.JavaConverters._
 
@@ -25,21 +25,21 @@ class TestSchemaConverter extends WordSpec with TestConfig with Matchers with Mo
     val cols: ColumnDefinitions = TestUtils.getColumnDefs
     val schema = CassandraUtils.convertToConnectSchema(cols.asScala.toList)
     val schemaFields = schema.fields().asScala
-    schemaFields.size shouldBe(cols.asList().size())
+    schemaFields.size shouldBe cols.asList().size()
     checkCols(schema)
   }
 
   "should convert a Cassandra row to a SourceRecord" in {
     val row = mock[Row]
     val cols = TestUtils.getColumnDefs
-    when(row.getColumnDefinitions()).thenReturn(cols)
+    when(row.getColumnDefinitions).thenReturn(cols)
     mockRow(row)
     val sr: Struct = CassandraUtils.convert(row)
     val schema = sr.schema()
     checkCols(schema)
-    sr.get("timeuuidCol").toString shouldBe(uuid.toString)
-    sr.get("intCol") shouldBe(0)
-    sr.get("mapCol") shouldBe("{}")
+    sr.get("timeuuidCol").toString shouldBe uuid.toString
+    sr.get("intCol") shouldBe 0
+    sr.get("mapCol") shouldBe "{}"
   }
 
 
@@ -71,24 +71,24 @@ class TestSchemaConverter extends WordSpec with TestConfig with Matchers with Mo
   }
 
   def checkCols(schema :Schema) = {
-    schema.field("uuidCol").schema().`type`() shouldBe(Schema.OPTIONAL_STRING_SCHEMA.`type`())
-    schema.field("inetCol").schema().`type`() shouldBe(Schema.OPTIONAL_STRING_SCHEMA.`type`())
-    schema.field("asciiCol").schema().`type`() shouldBe(Schema.OPTIONAL_STRING_SCHEMA.`type`())
-    schema.field("textCol").schema().`type`() shouldBe(Schema.OPTIONAL_STRING_SCHEMA.`type`())
-    schema.field("varcharCol").schema().`type`() shouldBe(Schema.OPTIONAL_STRING_SCHEMA.`type`())
-    schema.field("booleanCol").schema().`type`() shouldBe(Schema.OPTIONAL_BOOLEAN_SCHEMA.`type`())
-    schema.field("smallintCol").schema().`type`() shouldBe(Schema.INT16_SCHEMA.`type`())
-    schema.field("intCol").schema().`type`() shouldBe(Schema.OPTIONAL_INT32_SCHEMA.`type`())
-    schema.field("decimalCol").schema().`type`() shouldBe(Schema.OPTIONAL_STRING_SCHEMA.`type`())
-    schema.field("floatCol").schema().`type`() shouldBe(Schema.OPTIONAL_FLOAT32_SCHEMA.`type`())
-    schema.field("counterCol").schema().`type`() shouldBe(Schema.OPTIONAL_INT64_SCHEMA.`type`())
-    schema.field("bigintCol").schema().`type`() shouldBe(Schema.OPTIONAL_INT64_SCHEMA.`type`())
-    schema.field("varintCol").schema().`type`() shouldBe(Schema.OPTIONAL_INT64_SCHEMA.`type`())
-    schema.field("doubleCol").schema().`type`() shouldBe(Schema.OPTIONAL_INT64_SCHEMA.`type`())
-    schema.field("timeuuidCol").schema().`type`() shouldBe(Schema.OPTIONAL_STRING_SCHEMA.`type`())
-    schema.field("blobCol").schema().`type`() shouldBe(Schema.OPTIONAL_BYTES_SCHEMA.`type`())
-    schema.field("timeCol").schema().`type`() shouldBe(Schema.OPTIONAL_INT64_SCHEMA.`type`())
-    schema.field("timestampCol").schema().`type`() shouldBe(Schema.OPTIONAL_STRING_SCHEMA.`type`())
-    schema.field("dateCol").schema().`type`() shouldBe(Schema.OPTIONAL_STRING_SCHEMA.`type`())
+    schema.field("uuidCol").schema().`type`() shouldBe Schema.OPTIONAL_STRING_SCHEMA.`type`()
+    schema.field("inetCol").schema().`type`() shouldBe Schema.OPTIONAL_STRING_SCHEMA.`type`()
+    schema.field("asciiCol").schema().`type`() shouldBe Schema.OPTIONAL_STRING_SCHEMA.`type`()
+    schema.field("textCol").schema().`type`() shouldBe Schema.OPTIONAL_STRING_SCHEMA.`type`()
+    schema.field("varcharCol").schema().`type`() shouldBe Schema.OPTIONAL_STRING_SCHEMA.`type`()
+    schema.field("booleanCol").schema().`type`() shouldBe Schema.OPTIONAL_BOOLEAN_SCHEMA.`type`()
+    schema.field("smallintCol").schema().`type`() shouldBe Schema.INT16_SCHEMA.`type`()
+    schema.field("intCol").schema().`type`() shouldBe Schema.OPTIONAL_INT32_SCHEMA.`type`()
+    schema.field("decimalCol").schema().`type`() shouldBe Schema.OPTIONAL_STRING_SCHEMA.`type`()
+    schema.field("floatCol").schema().`type`() shouldBe Schema.OPTIONAL_FLOAT32_SCHEMA.`type`()
+    schema.field("counterCol").schema().`type`() shouldBe Schema.OPTIONAL_INT64_SCHEMA.`type`()
+    schema.field("bigintCol").schema().`type`() shouldBe Schema.OPTIONAL_INT64_SCHEMA.`type`()
+    schema.field("varintCol").schema().`type`() shouldBe Schema.OPTIONAL_INT64_SCHEMA.`type`()
+    schema.field("doubleCol").schema().`type`() shouldBe Schema.OPTIONAL_INT64_SCHEMA.`type`()
+    schema.field("timeuuidCol").schema().`type`() shouldBe Schema.OPTIONAL_STRING_SCHEMA.`type`()
+    schema.field("blobCol").schema().`type`() shouldBe Schema.OPTIONAL_BYTES_SCHEMA.`type`()
+    schema.field("timeCol").schema().`type`() shouldBe Schema.OPTIONAL_INT64_SCHEMA.`type`()
+    schema.field("timestampCol").schema().`type`() shouldBe Schema.OPTIONAL_STRING_SCHEMA.`type`()
+    schema.field("dateCol").schema().`type`() shouldBe Schema.OPTIONAL_STRING_SCHEMA.`type`()
   }
 }

--- a/kafka-connect-druid/build.gradle
+++ b/kafka-connect-druid/build.gradle
@@ -9,9 +9,9 @@ project(":kafka-connect-druid") {
     }
 
     dependencies {
+        compile "com.github.nscala-time:nscala-time_$scalaMajorVersion:2.12.0"
         compile "com.datamountaineer:kafka-connect-common:$dataMountaineerCommonVersion"
         compile "io.druid:tranquility-core_$scalaMajorVersion:$tranquilityCoreVersion"
         testCompile("org.kitesdk:kite-minicluster:$kiteMiniClusterVersion")
-        testCompile("org.apache.hbase:hbase-server:$hbaseServerVersion")
     }
 }

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/DruidSinkConnector.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/DruidSinkConnector.scala
@@ -17,15 +17,12 @@
 package com.datamountaineer.streamreactor.connect.druid
 
 import java.util
-
-import com.datamountaineer.streamreactor.connect.druid.config.DruidSinkConfig
+import scala.collection.JavaConverters._
 import com.typesafe.scalalogging.slf4j.StrictLogging
-import org.apache.kafka.common.config.ConfigDef
+import io.confluent.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
 import org.apache.kafka.connect.sink.SinkConnector
-
-import scala.collection.JavaConverters._
-import scala.util.{Failure, Try}
+import com.datamountaineer.streamreactor.connect.druid.config._
 
 /**
   *

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/DruidSinkTask.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/DruidSinkTask.scala
@@ -17,13 +17,13 @@
 package com.datamountaineer.streamreactor.connect.druid
 
 import java.util
-import com.datamountaineer.streamreactor.connect.druid.config.{DruidSinkConfig, DruidSinkSettings}
-import com.datamountaineer.streamreactor.connect.druid.writer.DruidDbWriter
-import com.typesafe.scalalogging.slf4j.StrictLogging
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
-import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.connect.sink.{SinkRecord, SinkTask}
 import scala.collection.JavaConversions._
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.connect.sink.{ SinkTask, SinkRecord }
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import org.apache.kafka.common.TopicPartition
+import com.datamountaineer.streamreactor.connect.druid.writer.DruidDbWriter
+import com.datamountaineer.streamreactor.connect.druid.config._
 
 /**
   * Created by andrew@datamountaineer.com on 04/03/16. 

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkConfig.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkConfig.scala
@@ -17,10 +17,8 @@
 package com.datamountaineer.streamreactor.connect.druid.config
 
 import java.util
-
-import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
-import org.apache.kafka.common.config.ConfigDef.{Importance, Type}
-
+import io.confluent.common.config.{ ConfigDef, AbstractConfig }
+import ConfigDef.{ Type, Importance }
 
 object DruidSinkConfig {
   val DATASOURCE_NAME = "connect.druid.sink.datasource.name"

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkSettings.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkSettings.scala
@@ -17,10 +17,10 @@
 package com.datamountaineer.streamreactor.connect.druid.config
 
 import java.io.File
-import com.datamountaineer.streamreactor.connect.druid.config.DruidSinkConfig._
-import com.datamountaineer.streamreactor.connect.schemas.PayloadFields
-import io.confluent.common.config.ConfigException
 import scala.util.Try
+import io.confluent.common.config.ConfigException
+import com.datamountaineer.streamreactor.connect.schemas.PayloadFields
+import DruidSinkConfig._
 
 case class DruidSinkSettings(datasourceName: String,
                              tranquilityConfig: String,

--- a/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/writer/DruidDbWriter.scala
+++ b/kafka-connect-druid/src/main/scala/com/datamountaineer/streamreactor/connect/druid/writer/DruidDbWriter.scala
@@ -17,17 +17,17 @@
 package com.datamountaineer.streamreactor.connect.druid.writer
 
 import java.io.ByteArrayInputStream
-import com.datamountaineer.streamreactor.connect.schemas.StructFieldsExtractor
-import com.datamountaineer.streamreactor.connect.druid.config.DruidSinkSettings
-import com.datamountaineer.streamreactor.connect.sink.DbWriter
-import com.metamx.tranquility.config.{PropertiesBasedConfig, TranquilityConfig}
-import com.metamx.tranquility.druid.DruidBeams
-import com.twitter.util.{Await, Future}
+import collection.JavaConversions._
 import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.twitter.util.{ Future, Await }
+import com.github.nscala_time.time.Imports._
 import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.sink.SinkRecord
-import org.joda.time.DateTime
-import scala.collection.JavaConversions._
+import com.datamountaineer.streamreactor.connect.schemas.StructFieldsExtractor
+import com.datamountaineer.streamreactor.connect.sink.DbWriter
+import com.metamx.tranquility.config.{ TranquilityConfig, PropertiesBasedConfig }
+import com.metamx.tranquility.druid.DruidBeams
+import com.datamountaineer.streamreactor.connect.druid.config.DruidSinkSettings
 
 /**
   * Responsible for writing the SinkRecord payload to Druid.

--- a/kafka-connect-druid/src/test/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkSettingsTest.scala
+++ b/kafka-connect-druid/src/test/scala/com/datamountaineer/streamreactor/connect/druid/config/DruidSinkSettingsTest.scala
@@ -1,13 +1,11 @@
 package com.datamountaineer.streamreactor.connect.druid.config
 
 import java.nio.file.Paths
-
-import org.apache.kafka.common.config.ConfigException
-import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
-import org.scalatest.{Matchers, WordSpec}
-
 import scala.collection.JavaConversions._
+import org.scalatest._
+import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito._
+import io.confluent.common.config.ConfigException
 
 class DruidSinkSettingsTest extends WordSpec with Matchers with MockitoSugar {
   "DruidSinkSettings" should {

--- a/kafka-connect-druid/src/test/scala/com/datamountaineer/streamreactor/connect/druid/writer/WikipediaSchemaBuilderFn.scala
+++ b/kafka-connect-druid/src/test/scala/com/datamountaineer/streamreactor/connect/druid/writer/WikipediaSchemaBuilderFn.scala
@@ -1,6 +1,6 @@
 package com.datamountaineer.streamreactor.connect.druid.writer
 
-import org.apache.kafka.connect.data.{Schema, SchemaBuilder}
+import org.apache.kafka.connect.data.{ Schema, SchemaBuilder }
 
 object WikipediaSchemaBuilderFn {
   def apply(): Schema = {

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticJsonWriter.scala
@@ -74,9 +74,9 @@ class ElasticJsonWriter(client: ElasticClient, settings: ElasticSettings) extend
   def insert(records: Map[String, Set[SinkRecord]]) : Iterable[Future[BulkResponse]] = {
     val ret = records.map({
       case (topic, sinkRecords) =>
-        val fields = settings.fields.get(topic).get
-        val ignoreFields = settings.ignoreFields.get(topic).get
-        val i = settings.tableMap.get(topic).get
+        val fields = settings.fields(topic)
+        val ignoreFields = settings.ignoreFields(topic)
+        val i = settings.tableMap(topic)
 
         val indexes = sinkRecords
                         .map(r => convert(r, fields, ignoreFields))

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticSinkConnector.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticSinkConnector.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
 import org.apache.kafka.connect.sink.SinkConnector
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 class ElasticSinkConnector extends SinkConnector with StrictLogging {
   private var configProps : Option[util.Map[String, String]] = None
@@ -43,7 +43,7 @@ class ElasticSinkConnector extends SinkConnector with StrictLogging {
     * */
   override def taskConfigs(maxTasks: Int): util.List[util.Map[String, String]] = {
     logger.info(s"Setting task configurations for $maxTasks workers.")
-    (1 to maxTasks).map(c => configProps.get).toList.asJava
+    (1 to maxTasks).map(c => configProps.get).toList
   }
 
   /**

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticSinkTask.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticSinkTask.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTask}
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 class ElasticSinkTask extends SinkTask with StrictLogging {
   private var writer : Option[ElasticJsonWriter] = None
@@ -53,7 +53,7 @@ class ElasticSinkTask extends SinkTask with StrictLogging {
 
     ElasticSinkConfig.config.parse(props)
     val sinkConfig = ElasticSinkConfig(props)
-    writer = Some(ElasticWriter(config = sinkConfig))
+    writer = Some(ElasticWriter(config = sinkConfig, context = context))
   }
 
   /**
@@ -61,7 +61,7 @@ class ElasticSinkTask extends SinkTask with StrictLogging {
     * */
   override def put(records: util.Collection[SinkRecord]): Unit = {
     require(writer.nonEmpty, "Writer is not set!")
-    writer.foreach(w=>w.write(records.asScala.toSet))
+    writer.foreach(w=>w.write(records.toSet))
   }
 
   /**

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticWriter.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticWriter.scala
@@ -18,10 +18,11 @@ package com.datamountaineer.streamreactor.connect.elastic
 
 import com.datamountaineer.streamreactor.connect.elastic.config.{ElasticSettings, ElasticSinkConfig}
 import com.sksamuel.elastic4s.{ElasticClient, ElasticsearchClientUri}
+import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.elasticsearch.common.settings.Settings
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 object  ElasticWriter {
   /**
@@ -30,7 +31,7 @@ object  ElasticWriter {
     * @param config An elasticSinkConfig to extract settings from.
     * @return An ElasticJsonWriter to write records from Kafka to ElasticSearch.
     * */
-  def apply(config: ElasticSinkConfig) : ElasticJsonWriter = {
+  def apply(config: ElasticSinkConfig, context: SinkTaskContext) : ElasticJsonWriter = {
     val hostNames = config.getString(ElasticSinkConfig.URL)
     val esClusterName = config.getString(ElasticSinkConfig.ES_CLUSTER_NAME)
     val esPrefix = config.getString(ElasticSinkConfig.URL_PREFIX)
@@ -42,6 +43,9 @@ object  ElasticWriter {
     val client = ElasticClient.transport(essettings, uri)
 
     val settings = ElasticSettings(config)
+    val assigned = context.assignment().map(a => a.topic()).toList
+    if (assigned.isEmpty) throw new ConnectException("No topics have been assigned to this task!")
+
     new ElasticJsonWriter(client = client, settings = settings)
   }
 }

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSettings.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSettings.scala
@@ -17,9 +17,8 @@
 package com.datamountaineer.streamreactor.connect.elastic.config
 
 import com.datamountaineer.connector.config.Config
-import org.apache.kafka.common.config.ConfigException
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 /**
   * Created by andrew@datamountaineer.com on 13/05/16. 
@@ -37,11 +36,11 @@ object ElasticSettings {
     val routes = raw.split(";").map(r => Config.parse(r)).toList
 
     val fields = routes.map(
-      rm => (rm.getSource, rm.getFieldAlias.asScala.map(fa => (fa.getField,fa.getAlias)).toMap)
+      rm => (rm.getSource, rm.getFieldAlias.map(fa => (fa.getField,fa.getAlias)).toMap)
     ).toMap
 
     val tableMap = routes.map(rm => (rm.getSource, rm.getTarget)).toMap
-    val ignoreFields = routes.map(rm => (rm.getSource, rm.getIgnoredField.asScala.toSet)).toMap
+    val ignoreFields = routes.map(rm => (rm.getSource, rm.getIgnoredField.toSet)).toMap
 
     ElasticSettings(routes = routes, fields = fields,ignoreFields = ignoreFields, tableMap = tableMap)
   }

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSinkConfig.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSinkConfig.scala
@@ -33,7 +33,7 @@ object ElasticSinkConfig {
   val URL_PREFIX_DOC = "URL connection string prefix"
   val URL_PREFIX_DEFAULT = "elasticsearch"
   val EXPORT_ROUTE_QUERY = "connect.elastic.export.route.query"
-  val EXPORT_ROUTE_QUERY_DOC = ""
+  val EXPORT_ROUTE_QUERY_DOC =  "KCQL expression describing field selection and routes."
 
   val config: ConfigDef = new ConfigDef()
     .define(URL, Type.STRING, URL_DEFAULT, Importance.HIGH, URL_DOC)

--- a/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticBase.scala
+++ b/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticBase.scala
@@ -7,7 +7,7 @@ import com.datamountaineer.streamreactor.connect.elastic.config.ElasticSinkConfi
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
-import org.scalatest.{BeforeAndAfter, FunSuite, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -17,7 +17,7 @@ trait TestElasticBase extends WordSpec with Matchers with BeforeAndAfter {
   val ELASTIC_SEARCH_HOSTNAMES = "localhost:9300"
   val TOPIC = "sink_test"
   val INDEX = "index_andrew"
-  var TMP : File = null
+  var TMP : File = _
   val QUERY = s"INSERT INTO $INDEX SELECT * FROM $TOPIC"
   val QUERY_SELECTION = s"INSERT INTO $INDEX SELECT id, string_field FROM $TOPIC"
 

--- a/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticWriter.scala
+++ b/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticWriter.scala
@@ -3,7 +3,7 @@ package com.datamountaineer.streamreactor.connect.elastic
 import com.datamountaineer.streamreactor.connect.elastic.config.{ElasticSettings, ElasticSinkConfig}
 import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.ElasticDsl._
-import org.apache.kafka.connect.sink.{SinkRecord, SinkTaskContext}
+import org.apache.kafka.connect.sink.SinkTaskContext
 import org.elasticsearch.common.settings.Settings
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar

--- a/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticWriterSelection.scala
+++ b/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticWriterSelection.scala
@@ -3,7 +3,7 @@ package com.datamountaineer.streamreactor.connect.elastic
 import com.datamountaineer.streamreactor.connect.elastic.config.{ElasticSettings, ElasticSinkConfig}
 import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.ElasticDsl._
-import org.apache.kafka.connect.sink.{SinkRecord, SinkTaskContext}
+import org.apache.kafka.connect.sink.SinkTaskContext
 import org.elasticsearch.common.settings.Settings
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/HbaseSinkConnector.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/HbaseSinkConnector.scala
@@ -22,11 +22,9 @@ import com.datamountaineer.streamreactor.connect.hbase.config.HbaseSinkConfig
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
-import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.sink.SinkConnector
 
 import scala.collection.JavaConverters._
-import scala.util.{Failure, Try}
 
 /**
   * <h1>HbaseSinkConnector</h1>

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/HbaseSinkTask.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/HbaseSinkTask.scala
@@ -24,9 +24,9 @@ import com.datamountaineer.streamreactor.connect.hbase.writers.{HbaseWriter, Wri
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTask}
 
-import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
 
 /**
@@ -61,6 +61,10 @@ class HbaseSinkTask extends SinkTask with StrictLogging {
     HbaseSinkConfig.config.parse(props)
     val sinkConfig = HbaseSinkConfig(props)
     val hbaseSettings = HbaseSettings(sinkConfig)
+
+    val assigned = context.assignment().map(a => a.topic()).toList
+    if (assigned.isEmpty) throw new ConnectException("No topics have been assigned to this task!")
+
 
     //if error policy is retry set retry interval
     if (hbaseSettings.errorPolicy.equals(ErrorPolicyEnum.RETRY)) {

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/RowKeyBuilderBytes.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/RowKeyBuilderBytes.scala
@@ -99,7 +99,7 @@ class AvroRecordRowKeyBuilderBytes(valuesExtractorsMap: Map[String, (Any) => Arr
     */
   override def build(record: SinkRecord, payload: Any): Array[Byte] = {
     val avroRecord = payload.asInstanceOf[GenericRecord]
-    val key = keys.map { case k =>
+    val key = keys.map { k =>
       val fn = valuesExtractorsMap.getOrElse(k, throw new IllegalArgumentException(s"Could not handle key builder for field:$k"))
       fn(avroRecord.get(k))
     }.flatMap(arr => Seq(delimBytes, arr))
@@ -121,7 +121,7 @@ case class StructFieldsRowKeyBuilderBytes(fm : List[String],
     val missingKeys = fm.filterNot(p => availableFields.contains(p))
     require(missingKeys.isEmpty, s"${missingKeys.mkString(",")} keys are not present in the SinkRecord payload:${availableFields.mkString(",")}")
 
-    val keyBytes = fm.map { case key =>
+    val keyBytes = fm.map { key =>
       val field = schema.field(key)
       val value = struct.get(field)
       require(value != null, s"$key field value is null. Non null value is required for the fileds creating the row key")

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/StructFieldsExtractorBytes.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/StructFieldsExtractorBytes.scala
@@ -16,9 +16,8 @@
 
 package com.datamountaineer.streamreactor.connect.hbase
 
-import org.apache.hadoop.hbase.util.Bytes
+import com.datamountaineer.streamreactor.connect.hbase.BytesHelper._
 import org.apache.kafka.connect.data.{Field, Schema, Struct}
-import BytesHelper._
 
 import scala.collection.JavaConversions._
 
@@ -37,9 +36,8 @@ case class StructFieldsExtractorBytes(includeAllFields: Boolean, fieldsAliasMap:
       schema.fields().filter(f => fieldsAliasMap.contains(f.name()))
     }
 
-    val fieldsAndValues = fields.flatMap { case field =>
-      getFieldBytes(field, struct).map(bytes => fieldsAliasMap.getOrElse(field.name(), field.name()) -> bytes)
-    }
+    val fieldsAndValues = fields.flatMap(field =>
+      getFieldBytes(field, struct).map(bytes => fieldsAliasMap.getOrElse(field.name(), field.name()) -> bytes))
 
     fieldsAndValues
   }

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/avro/AvroRecordFieldExtractorMapFn.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/avro/AvroRecordFieldExtractorMapFn.scala
@@ -33,7 +33,7 @@ object AvroRecordFieldExtractorMapFn {
     * @return A map of functions converting the avro field value to bytes depending on the avro field type
     */
   def apply(schema: Schema, fields: Seq[String]): Map[String, (Any) => Array[Byte]] = {
-    fields.map { case fn =>
+    fields.map { fn =>
       val f = schema.getField(fn)
       if (f == null) {
         throw new IllegalArgumentException(s"$fn does not exist in the given schema.")

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/avro/AvroSchemaFieldsExistFn.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/avro/AvroSchemaFieldsExistFn.scala
@@ -23,7 +23,7 @@ import org.apache.avro.{AvroRuntimeException, Schema}
   */
 object AvroSchemaFieldsExistFn {
   def apply(schema: Schema, fields: Seq[String]) : Unit = {
-    fields.foreach { case field =>
+    fields.foreach { field =>
       try {
         if (Option(schema.getField(field)).isEmpty) {
           throw new IllegalArgumentException(s"[$field] is not found in the schema fields")

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/config/HbaseSettings.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/config/HbaseSettings.scala
@@ -18,12 +18,12 @@ package com.datamountaineer.streamreactor.connect.hbase.config
 
 import com.datamountaineer.connector.config.Config
 import com.datamountaineer.streamreactor.connect.errors.{ErrorPolicy, ErrorPolicyEnum, ThrowErrorPolicy}
-import com.datamountaineer.streamreactor.connect.hbase.{GenericRowKeyBuilderBytes, RowKeyBuilderBytes, StructFieldsExtractorBytes, StructFieldsRowKeyBuilderBytes}
 import com.datamountaineer.streamreactor.connect.hbase.config.HbaseSinkConfig._
+import com.datamountaineer.streamreactor.connect.hbase.{GenericRowKeyBuilderBytes, RowKeyBuilderBytes, StructFieldsExtractorBytes, StructFieldsRowKeyBuilderBytes}
 import org.apache.kafka.common.config.ConfigException
 
-import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 case class HbaseSettings(columnFamilyMap: String,
                          rowKeyModeMap : Map[String, RowKeyBuilderBytes],
@@ -62,7 +62,7 @@ object HbaseSettings {
     val fields = routes.map(rm => (rm.getSource, rm.getFieldAlias.map(fa => (fa.getField,fa.getAlias)).toMap)).toMap
 
     val extractorFields = routes.map(rm => {
-      (rm.getSource, StructFieldsExtractorBytes(rm.isIncludeAllFields , fields.get(rm.getSource).get))
+      (rm.getSource, StructFieldsExtractorBytes(rm.isIncludeAllFields , fields(rm.getSource)))
     }).toMap
 
     new HbaseSettings(columnFamily, rowKeyModeMap, routes.toList, extractorFields, errorPolicy, nbrOfRetries)

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/config/HbaseSinkConfig.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/config/HbaseSinkConfig.scala
@@ -18,15 +18,15 @@ package com.datamountaineer.streamreactor.connect.hbase.config
 
 import java.util
 
-import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 import org.apache.kafka.common.config.ConfigDef.{Importance, Type}
+import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 
 object HbaseSinkConfig {
   val COLUMN_FAMILY = "connect.hbase.sink.column.family"
   val COLUMN_FAMILY_DOC = "The hbase column family."
 
   val EXPORT_ROUTE_QUERY = "connect.hbase.export.route.query"
-  val EXPORT_ROUTE_QUERY_DOC = ""
+  val EXPORT_ROUTE_QUERY_DOC = "KCQL expression describing field selection and routes."
 
   val ERROR_POLICY = "connect.hbase.error.policy"
   val ERROR_POLICY_DOC = "Specifies the action to be taken if an error occurs while inserting the data.\n" +

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/writers/HbaseWriter.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/writers/HbaseWriter.scala
@@ -74,14 +74,14 @@ class HbaseWriter(settings: HbaseSettings
 
     records.foreach({
       case (topic, sinkRecords : Seq[SinkRecord]) =>
-        val table = tables.get(topic).get
+        val table = tables(topic)
         val puts = sinkRecords.flatMap { record =>
 
           require(record.value() != null && record.value().getClass == classOf[Struct],
             "The SinkRecord payload should be of type Struct")
 
-          val keyBuilder = rowKeyMap.get(topic).get
-          val extractor = settings.extractorFields.get(topic).get
+          val keyBuilder = rowKeyMap(topic)
+          val extractor = settings.extractorFields(topic)
           val fieldsAndValues = extractor.get(record.value.asInstanceOf[Struct])
 
           if (fieldsAndValues.nonEmpty) {
@@ -91,7 +91,7 @@ class HbaseWriter(settings: HbaseSettings
               if (!columnsBytesMap.contains(fieldName)) {
                 columnsBytesMap = columnsBytesMap + (fieldName -> Bytes.toBytes(fieldName))
               }
-              put.addColumn(columnFamilyBytes, columnsBytesMap.get(fieldName).get, bytes)
+              put.addColumn(columnFamilyBytes, columnsBytesMap(fieldName), bytes)
             }
             Some(put)
           }

--- a/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/writers/WriterFactoryFn.scala
+++ b/kafka-connect-hbase/src/main/scala/com/datamountaineer/streamreactor/connect/hbase/writers/WriterFactoryFn.scala
@@ -30,7 +30,6 @@ object WriterFactoryFn extends StrictLogging {
     * @param settings HbaseSetting for the writer
     * @return
     */
-  def apply(settings: HbaseSettings): HbaseWriter = {
-    new HbaseWriter(settings)
-  }
+  def apply(settings: HbaseSettings): HbaseWriter = new HbaseWriter(settings)
+
 }

--- a/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/AvroRecordRowKeyBuilderTest.scala
+++ b/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/AvroRecordRowKeyBuilderTest.scala
@@ -26,7 +26,7 @@ class AvroRecordRowKeyBuilderTest extends WordSpec with Matchers with MockitoSug
 
         val values: Map[String, AnyRef] = Map("firstName" -> firstName, "lastName" -> lastName, "age" -> Int.box(age))
 
-        override def get(key: String): AnyRef = values.get(key).get
+        override def get(key: String): AnyRef = values(key)
 
         override def put(key: String, v: scala.Any): Unit = sys.error("not supported")
 

--- a/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/GenericRowKeyBuilderTest.scala
+++ b/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/GenericRowKeyBuilderTest.scala
@@ -1,6 +1,6 @@
 package com.datamountaineer.streamreactor.connect.hbase
 
-import BytesHelper._
+import com.datamountaineer.streamreactor.connect.hbase.BytesHelper._
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.sink.SinkRecord

--- a/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/StructFieldsExtractorTest.scala
+++ b/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/StructFieldsExtractorTest.scala
@@ -18,11 +18,11 @@ class StructFieldsExtractorTest extends WordSpec with Matchers {
         .put("lastName", "Smith")
         .put("age", 30)
 
-      val map = new StructFieldsExtractorBytes(true, Map.empty).get(struct).toMap
+      val map = StructFieldsExtractorBytes(true, Map.empty).get(struct).toMap
 
-      Bytes.toString(map.get("firstName").get) shouldBe "Alex"
-      Bytes.toString(map.get("lastName").get) shouldBe "Smith"
-      Bytes.toInt(map.get("age").get) shouldBe 30
+      Bytes.toString(map("firstName")) shouldBe "Alex"
+      Bytes.toString(map("lastName")) shouldBe "Smith"
+      Bytes.toInt(map("age")) shouldBe 30
 
     }
 
@@ -38,11 +38,11 @@ class StructFieldsExtractorTest extends WordSpec with Matchers {
         .put("lastName", "Smith")
         .put("age", 30)
 
-      val map = new StructFieldsExtractorBytes(true, Map("lastName" -> "Name", "age" -> "a")).get(struct).toMap
+      val map = StructFieldsExtractorBytes(true, Map("lastName" -> "Name", "age" -> "a")).get(struct).toMap
 
-      Bytes.toString(map.get("firstName").get) shouldBe "Alex"
-      Bytes.toString(map.get("Name").get) shouldBe "Smith"
-      Bytes.toInt(map.get("a").get) shouldBe 30
+      Bytes.toString(map("firstName")) shouldBe "Alex"
+      Bytes.toString(map("Name")) shouldBe "Smith"
+      Bytes.toInt(map("a")) shouldBe 30
 
     }
 
@@ -58,10 +58,10 @@ class StructFieldsExtractorTest extends WordSpec with Matchers {
         .put("lastName", "Smith")
         .put("age", 30)
 
-      val map = new StructFieldsExtractorBytes(false, Map("lastName" -> "Name", "age" -> "age")).get(struct).toMap
+      val map = StructFieldsExtractorBytes(false, Map("lastName" -> "Name", "age" -> "age")).get(struct).toMap
 
-      Bytes.toString(map.get("Name").get) shouldBe "Smith"
-      Bytes.toInt(map.get("age").get) shouldBe 30
+      Bytes.toString(map("Name")) shouldBe "Smith"
+      Bytes.toInt(map("age")) shouldBe 30
 
       map.size shouldBe 2
     }

--- a/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/avro/AvroRecordFieldExtractorMapFnTest.scala
+++ b/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/avro/AvroRecordFieldExtractorMapFnTest.scala
@@ -26,11 +26,11 @@ class AvroRecordFieldExtractorMapFnTest extends WordSpec with Matchers {
     "create the mappings for all the given fields" in {
       val mappings = AvroRecordFieldExtractorMapFn(schema, Seq("firstName", "age"))
 
-      val fnFirstName = mappings.get("firstName").get
+      val fnFirstName = mappings("firstName")
       val firstName = "Beaky"
       fnFirstName(firstName) shouldBe Bytes.toBytes(firstName)
 
-      val fnAge = mappings.get("age").get
+      val fnAge = mappings("age")
       val age = 31
       fnAge(age) shouldBe Bytes.toBytes(age)
       intercept[ClassCastException] {

--- a/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/config/HbaseSettingsTest.scala
+++ b/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/config/HbaseSettingsTest.scala
@@ -40,7 +40,7 @@ class HbaseSettingsTest extends WordSpec with Matchers with MockitoSugar {
     val settings = HbaseSettings(config)
     val route = settings.routes.head
 
-    settings.rowKeyModeMap.get(TABLE_NAME_RAW).get.isInstanceOf[StructFieldsRowKeyBuilderBytes] shouldBe true
+    settings.rowKeyModeMap(TABLE_NAME_RAW).isInstanceOf[StructFieldsRowKeyBuilderBytes] shouldBe true
 
     route.isIncludeAllFields shouldBe true
     route.getTarget shouldBe TABLE_NAME_RAW
@@ -57,7 +57,7 @@ class HbaseSettingsTest extends WordSpec with Matchers with MockitoSugar {
 
     val settings = HbaseSettings(config)
 
-    settings.rowKeyModeMap.get(TABLE_NAME_RAW).get.isInstanceOf[GenericRowKeyBuilderBytes] shouldBe true
+    settings.rowKeyModeMap(TABLE_NAME_RAW).isInstanceOf[GenericRowKeyBuilderBytes] shouldBe true
     val route = settings.routes.head
 
     route.isIncludeAllFields shouldBe true
@@ -77,7 +77,7 @@ class HbaseSettingsTest extends WordSpec with Matchers with MockitoSugar {
     val route = settings.routes.head
     val fields = route.getFieldAlias.asScala.toList
 
-    settings.rowKeyModeMap.get(TABLE_NAME_RAW).get.isInstanceOf[GenericRowKeyBuilderBytes] shouldBe true
+    settings.rowKeyModeMap(TABLE_NAME_RAW).isInstanceOf[GenericRowKeyBuilderBytes] shouldBe true
 
     route.isIncludeAllFields shouldBe false
     route.getSource shouldBe TABLE_NAME_RAW
@@ -100,7 +100,7 @@ class HbaseSettingsTest extends WordSpec with Matchers with MockitoSugar {
     val route = settings.routes.head
     val fields = route.getFieldAlias.asScala.toList
 
-    settings.rowKeyModeMap.get(TABLE_NAME_RAW).get.isInstanceOf[StructFieldsRowKeyBuilderBytes] shouldBe true
+    settings.rowKeyModeMap(TABLE_NAME_RAW).isInstanceOf[StructFieldsRowKeyBuilderBytes] shouldBe true
 
     route.isIncludeAllFields shouldBe false
     route.getSource shouldBe TABLE_NAME_RAW

--- a/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/writers/HbaseReaderHelper.scala
+++ b/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/writers/HbaseReaderHelper.scala
@@ -18,7 +18,7 @@ object HbaseReaderHelper {
       val scan = new Scan()
       scan.addFamily(columnFamily.fromString())
       val scanner = tbl.getScanner(scan)
-      scanner.map { case rs =>
+      scanner.map { rs =>
         val cells = rs.rawCells().map { cell =>
           Bytes.toString(CellUtil.cloneQualifier(cell)) -> CellUtil.cloneValue(cell)
         }.toMap

--- a/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/writers/HbaseWriterTest.scala
+++ b/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/writers/HbaseWriterTest.scala
@@ -1,18 +1,17 @@
 package com.datamountaineer.streamreactor.connect.hbase.writers
 
-import com.datamountaineer.streamreactor.connect.hbase.config.{HbaseSettings, HbaseSinkConfig}
-import com.datamountaineer.streamreactor.connect.hbase.config.HbaseSinkConfig._
 import com.datamountaineer.streamreactor.connect.hbase.BytesHelper._
-import com.datamountaineer.streamreactor.connect.hbase.FieldsValuesExtractor
+import com.datamountaineer.streamreactor.connect.hbase.config.HbaseSinkConfig._
+import com.datamountaineer.streamreactor.connect.hbase.config.{HbaseSettings, HbaseSinkConfig}
+import com.datamountaineer.streamreactor.connect.hbase.{FieldsValuesExtractor, HbaseHelper, HbaseTableHelper, StructFieldsRowKeyBuilderBytes}
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
 import org.json4s.DefaultFormats
+import org.kitesdk.minicluster._
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
-import com.datamountaineer.streamreactor.connect.hbase.{HbaseHelper, HbaseTableHelper, StructFieldsRowKeyBuilderBytes}
-import org.kitesdk.minicluster._
 
 class HbaseWriterTest extends WordSpec with Matchers with MockitoSugar with BeforeAndAfter {
 
@@ -89,16 +88,16 @@ class HbaseWriterTest extends WordSpec with Matchers with MockitoSugar with Befo
           val row1 = data.filter { r => Bytes.toString(r.key) == "Alex" }.head
           row1.cells.size shouldBe 2
 
-          Bytes.toString(row1.cells.get("firstName").get) shouldBe "Alex"
-          Bytes.toInt(row1.cells.get("age").get) shouldBe 30
+          Bytes.toString(row1.cells("firstName")) shouldBe "Alex"
+          Bytes.toInt(row1.cells("age")) shouldBe 30
 
 
           val row2 = data.filter { r => Bytes.toString(r.key) == "Mara" }.head
           row2.cells.size shouldBe 3
 
-          Bytes.toString(row2.cells.get("firstName").get) shouldBe "Mara"
-          Bytes.toInt(row2.cells.get("age").get) shouldBe 22
-          Bytes.toDouble(row2.cells.get("threshold").get) shouldBe 12.4
+          Bytes.toString(row2.cells("firstName")) shouldBe "Mara"
+          Bytes.toInt(row2.cells("age")) shouldBe 22
+          Bytes.toDouble(row2.cells("threshold")) shouldBe 12.4
 
         }
         finally {
@@ -153,16 +152,16 @@ class HbaseWriterTest extends WordSpec with Matchers with MockitoSugar with Befo
           val row1 = data.filter { r => Bytes.toString(r.key).equals(s"$topic|1|0") }.head
           row1.cells.size shouldBe 2
 
-          Bytes.toString(row1.cells.get("firstName").get) shouldBe "Alex"
-          Bytes.toInt(row1.cells.get("age").get) shouldBe 30
+          Bytes.toString(row1.cells("firstName")) shouldBe "Alex"
+          Bytes.toInt(row1.cells("age")) shouldBe 30
 
 
           val row2 = data.filter { r => Bytes.toString(r.key).equals(s"$topic|1|1") }.head
           row2.cells.size shouldBe 3
 
-          Bytes.toString(row2.cells.get("firstName").get) shouldBe "Mara"
-          Bytes.toInt(row2.cells.get("age").get) shouldBe 22
-          Bytes.toDouble(row2.cells.get("threshold").get) shouldBe 12.4
+          Bytes.toString(row2.cells("firstName")) shouldBe "Mara"
+          Bytes.toInt(row2.cells("age")) shouldBe 22
+          Bytes.toDouble(row2.cells("threshold")) shouldBe 12.4
 
         }
         finally {

--- a/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/writers/HbaseWriterTestRetry.scala
+++ b/kafka-connect-hbase/src/test/scala/com/datamountaineer/streamreactor/connect/hbase/writers/HbaseWriterTestRetry.scala
@@ -1,10 +1,9 @@
 package com.datamountaineer.streamreactor.connect.hbase.writers
 
+import com.datamountaineer.streamreactor.connect.hbase.BytesHelper._
 import com.datamountaineer.streamreactor.connect.hbase.config.HbaseSinkConfig._
 import com.datamountaineer.streamreactor.connect.hbase.config.{HbaseSettings, HbaseSinkConfig}
-import com.datamountaineer.streamreactor.connect.hbase.{HbaseHelper, HbaseTableHelper, StructFieldsRowKeyBuilderBytes}
-import com.datamountaineer.streamreactor.connect.hbase.BytesHelper._
-import com.datamountaineer.streamreactor.connect.hbase.FieldsValuesExtractor
+import com.datamountaineer.streamreactor.connect.hbase.{FieldsValuesExtractor, HbaseHelper, HbaseTableHelper, StructFieldsRowKeyBuilderBytes}
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.errors.RetriableException
@@ -100,16 +99,16 @@ class HbaseWriterTestRetry extends WordSpec with Matchers with MockitoSugar with
           val row1 = data.filter { r => Bytes.toString(r.key) == "Alex" }.head
           row1.cells.size shouldBe 2
 
-          Bytes.toString(row1.cells.get("firstName").get) shouldBe "Alex"
-          Bytes.toInt(row1.cells.get("age").get) shouldBe 30
+          Bytes.toString(row1.cells("firstName")) shouldBe "Alex"
+          Bytes.toInt(row1.cells("age")) shouldBe 30
 
 
           val row2 = data.filter { r => Bytes.toString(r.key) == "Mara" }.head
           row2.cells.size shouldBe 3
 
-          Bytes.toString(row2.cells.get("firstName").get) shouldBe "Mara"
-          Bytes.toInt(row2.cells.get("age").get) shouldBe 22
-          Bytes.toDouble(row2.cells.get("threshold").get) shouldBe 12.4
+          Bytes.toString(row2.cells("firstName")) shouldBe "Mara"
+          Bytes.toInt(row2.cells("age")) shouldBe 22
+          Bytes.toDouble(row2.cells("threshold")) shouldBe 12.4
 
         }
         finally {

--- a/kafka-connect-jms/README.md
+++ b/kafka-connect-jms/README.md
@@ -3,7 +3,7 @@
 
 ## Kafka Connect JMS Sink
 
-A Kafka Sink Connector to write the records to JMS queue or topic. The connector takes the value from the Kafka Connect SinkRecor and
+A Kafka Sink Connector to write the records to JMS queue or topic. The connector takes the value from the Kafka Connect SinkRecord and
 puts it on the JMS topic/queue.
 
 ## Prerequisites
@@ -24,11 +24,11 @@ In addition to the default topics configuration the following options are added:
 | connect.jms.sink.password | String | | Specifies the password for the user to connect to the JMS endpoint. |
 | connect.jms.sink.connection.factory | String | Yes| Specifies the JMS connection factory class |
 | connect.jms.sink.export.route.query | String | Yes| The KCQL expressing what gets sourced from Kafka and where it lands in JMS. Check: https://github.com/datamountaineer/kafka-connect-query-language for details|
-| connect.jms.sink.export.route.topics | String | Yes| Specifies the JMS topics. The KCQL target points to the JMS destination. If the destintion is meant to a topic then it should be present in this list|
-| connect.jms.sink.export.route.queues| String | Yes| Specifies the JMS queues. The KCQL target points to the JMS destination. If the destintion is meant to a queue then it should be present in this list|
-| connect.jms.sink.message.type| String | Yes| Specifies the JMS payload. If JSON is chosen it will send a TextMessage; if AVRO is chosen it will send a BytesMessage;if MAP is chosen it will send a MapMessage;if OBJECT is chosend it will send an ObjectMessage|
+| connect.jms.sink.export.route.topics | String | Yes| Specifies the JMS topics. The KCQL target points to the JMS destination. If the destination is meant to a topic then it should be present in this list|
+| connect.jms.sink.export.route.queues| String | Yes| Specifies the JMS queues. The KCQL target points to the JMS destination. If the destination is meant to a queue then it should be present in this list|
+| connect.jms.sink.message.type| String | Yes| Specifies the JMS payload. If JSON is chosen it will send a TextMessage; if AVRO is chosen it will send a BytesMessage;if MAP is chosen it will send a MapMessage;if OBJECT is chosen it will send an ObjectMessage|
 | connect.jms.error.policy| String | Yes| There are two available options: NOOP - the error is swallowed ;THROW - the error is allowed to propagate. RETRY - The exception causes the Connect framework to retry the message. The number of retries is based on the error will be logged automatically|
-| connect.jms.retry.interval | INT | | The time elapsed between retring to send the messages to the JMS in case of a previous error|
+| connect.jms.retry.interval | INT | | The time elapsed between retrying to send the messages to the JMS in case of a previous error|
 
 Example jms.properties file
 
@@ -62,7 +62,7 @@ gradle fatJar
 * Copy the JMS sink jar from your build location to `$CONFLUENT_HOME/share/java/kafka-connect-jms`
 
 ```bash
-mkdir $CONFLUENT_HOME/share/java/kafka-connect-jms
+mkdir ${CONFLUENT_HOME}/share/java/kafka-connect-jms
 cp target/kafka-connect-jms-0.1-all.jar  $CONFLUENT_HOME/share/java/kafka-connect-jms/
 ```
 

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSinkTask.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSinkTask.scala
@@ -1,18 +1,20 @@
-/**
-  * Copyright 2016 Datamountaineer.
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  **/
+/*
+ * *
+ *   * Copyright 2016 Datamountaineer.
+ *   *
+ *   * Licensed under the Apache License, Version 2.0 (the "License");
+ *   * you may not use this file except in compliance with the License.
+ *   * You may obtain a copy of the License at
+ *   *
+ *   * http://www.apache.org/licenses/LICENSE-2.0
+ *   *
+ *   * Unless required by applicable law or agreed to in writing, software
+ *   * distributed under the License is distributed on an "AS IS" BASIS,
+ *   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   * See the License for the specific language governing permissions and
+ *   * limitations under the License.
+ *   *
+ */
 
 package com.datamountaineer.streamreactor.connect.jms
 
@@ -24,8 +26,10 @@ import com.datamountaineer.streamreactor.connect.jms.sink.writer.JMSWriter
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTask}
 
+import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
 /**
@@ -59,6 +63,9 @@ class JMSSinkTask extends SinkTask with StrictLogging {
     JMSSinkConfig.config.parse(props)
     val sinkConfig = new JMSSinkConfig(props)
     val settings = JMSSettings(sinkConfig)
+
+    val assigned = context.assignment().map(a => a.topic()).toList
+    if (assigned.isEmpty) throw new ConnectException("No topics have been assigned to this task!")
 
     //if error policy is retry set retry interval
     if (settings.errorPolicy.equals(ErrorPolicyEnum.RETRY)) {

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/config/JMSSinkConfig.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/config/JMSSinkConfig.scala
@@ -36,7 +36,7 @@ object JMSSinkConfig {
   private val CONNECTION_FACTORY_DOC = "Provides the full class name for the ConnectionFactory implementation to use."
 
   val EXPORT_ROUTE_QUERY = "connect.jms.sink.export.route.query"
-  val EXPORT_ROUTE_QUERY_DOC = ""
+  val EXPORT_ROUTE_QUERY_DOC =  "KCQL expression describing field selection and routes."
 
   val TOPICS_LIST = "connect.jms.sink.export.route.topics"
   private val TOPICS_LIST_DOC = "Lists all the jms target topics"
@@ -50,7 +50,7 @@ object JMSSinkConfig {
       |Specifies the JMS payload. If JSON is chosen it will send a TextMessage;
       |if AVRO is chosen it will send a BytesMessage;
       |if MAP is chosen it will send a MapMessage
-      |if OBJECT is chosend it will send an ObjectMessage""".stripMargin
+      |if OBJECT is chosen it will send an ObjectMessage""".stripMargin
 
   val ERROR_POLICY = "connect.jms.error.policy"
   val ERROR_POLICY_DOC = "Specifies the action to be taken if an error occurs while inserting the data.\n" +

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/config/MessageType.java
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/config/MessageType.java
@@ -1,19 +1,3 @@
-/**
- * Copyright 2016 Datamountaineer.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- **/
-
 package com.datamountaineer.streamreactor.connect.jms.sink.config;
 
 public enum MessageType {

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/writer/converters/ObjectMessageConverter.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/sink/writer/converters/ObjectMessageConverter.scala
@@ -19,8 +19,9 @@ import javax.jms.{Message, ObjectMessage, Session}
 
 import org.apache.kafka.connect.data.{Schema, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
-import scala.collection.JavaConverters._
+
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class ObjectMessageConverter extends JMSMessageConverter {
   override def convert(record: SinkRecord, session: Session): Message = {

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/JMSSinkTaskTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/JMSSinkTaskTest.scala
@@ -89,7 +89,7 @@ class JMSSinkTaskTest extends WordSpec with Matchers with Using with BeforeAndAf
           val topicConsumer = session.createConsumer(topic)
 
           val topicMsgListener = new MessageListener {
-            @volatile var msg: Message = null
+            @volatile var msg: Message = _
 
             override def onMessage(message: Message): Unit = {
               msg = message
@@ -101,7 +101,7 @@ class JMSSinkTaskTest extends WordSpec with Matchers with Using with BeforeAndAf
           val consumerQueue = session.createConsumer(queue)
 
           val queueMsgListener = new MessageListener {
-            @volatile var msg: Message = null
+            @volatile var msg: Message = _
 
             override def onMessage(message: Message): Unit = {
               msg = message

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/JMSWriterTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/JMSWriterTest.scala
@@ -86,7 +86,7 @@ class JMSWriterTest extends WordSpec with Matchers with Using with BeforeAndAfte
           val topicConsumer = session.createConsumer(topic)
 
           val topicMsgListener = new MessageListener {
-            @volatile var msg: Message = null
+            @volatile var msg: Message = _
 
             override def onMessage(message: Message): Unit = {
               msg = message
@@ -98,7 +98,7 @@ class JMSWriterTest extends WordSpec with Matchers with Using with BeforeAndAfte
           val consumerQueue = session.createConsumer(queue)
 
           val queueMsgListener = new MessageListener {
-            @volatile var msg: Message = null
+            @volatile var msg: Message = _
 
             override def onMessage(message: Message): Unit = {
               msg = message
@@ -112,8 +112,8 @@ class JMSWriterTest extends WordSpec with Matchers with Using with BeforeAndAfte
                 brokerUrl,
                 classOf[ActiveMQConnectionFactory],
                 List(
-                  JMSConfig(TopicDestination, kafkaTopic1, jmsTopic, true, Map("int8" -> "byte", "int16" -> "short")),
-                  JMSConfig(QueueDestination, kafkaTopic2, jmsQueue, true, Map("int32" -> "int", "int64" -> "long"))),
+                  JMSConfig(TopicDestination, kafkaTopic1, jmsTopic, includeAllFields = true, Map("int8" -> "byte", "int16" -> "short")),
+                  JMSConfig(QueueDestination, kafkaTopic2, jmsQueue, includeAllFields = true, Map("int32" -> "int", "int64" -> "long"))),
                 None,
                 None,
                 MessageType.JSON,

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/converters/AvroMessageConverterTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/converters/AvroMessageConverterTest.scala
@@ -8,12 +8,11 @@ import com.datamountaineer.streamreactor.connect.jms.sink.writer.converters.Avro
 import com.sksamuel.scalax.io.Using
 import io.confluent.connect.avro.AvroData
 import org.apache.activemq.ActiveMQConnectionFactory
-import org.apache.activemq.broker.BrokerService
 import org.apache.avro.generic.GenericData
 import org.apache.avro.util.Utf8
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
-import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
+import org.scalatest.{Matchers, WordSpec}
 
 import scala.collection.JavaConverters._
 

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/converters/JsonMessageConverterTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/converters/JsonMessageConverterTest.scala
@@ -5,10 +5,9 @@ import javax.jms.TextMessage
 import com.datamountaineer.streamreactor.connect.jms.sink.writer.converters.JsonMessageConverter
 import com.sksamuel.scalax.io.Using
 import org.apache.activemq.ActiveMQConnectionFactory
-import org.apache.activemq.broker.BrokerService
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
-import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
+import org.scalatest.{Matchers, WordSpec}
 
 import scala.collection.JavaConverters._
 

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/converters/MapMessageConverterTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/converters/MapMessageConverterTest.scala
@@ -5,7 +5,6 @@ import javax.jms.MapMessage
 import com.datamountaineer.streamreactor.connect.jms.sink.writer.converters.MapMessageConverter
 import com.sksamuel.scalax.io.Using
 import org.apache.activemq.ActiveMQConnectionFactory
-import org.apache.activemq.broker.BrokerService
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/converters/ObjectMessageConverterTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/writer/converters/ObjectMessageConverterTest.scala
@@ -1,8 +1,7 @@
 package com.datamountaineer.streamreactor.connect.writer.converters
 
-import javax.jms.{BytesMessage, ObjectMessage}
+import javax.jms.ObjectMessage
 
-import com.datamountaineer.streamreactor.connect.IteratorToSeqFn
 import com.datamountaineer.streamreactor.connect.jms.sink.writer.converters.ObjectMessageConverter
 import com.sksamuel.scalax.io.Using
 import org.apache.activemq.ActiveMQConnectionFactory

--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/config/KuduSettings.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/config/KuduSettings.scala
@@ -14,35 +14,35 @@
   * limitations under the License.
   **/
 
-package com.datamountaineer.streamreactor.connect.config
+package com.datamountaineer.streamreactor.connect.kudu.config
 
 import com.datamountaineer.connector.config.{Config, WriteModeEnum}
 import com.datamountaineer.streamreactor.connect.errors.{ErrorPolicy, ErrorPolicyEnum, ThrowErrorPolicy}
-import org.apache.kafka.common.config.{AbstractConfig, ConfigException}
 
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
 
 /**
   * Created by andrew@datamountaineer.com on 13/05/16. 
   * stream-reactor-maven
   */
-case class KuduSetting(routes: List[Config],
-                       topicTables : Map[String, String],
-                       allowAutoCreate: Map[String, Boolean],
-                       allowAutoEvolve: Map[String, Boolean],
-                       fieldsMap : Map[String, Map[String, String]],
-                       ignoreFields: Map[String, Set[String]],
-                       writeModeMap : Map[String, WriteModeEnum],
-                       errorPolicy: ErrorPolicy = new ThrowErrorPolicy,
-                       maxRetries: Int = KuduSinkConfig.NBR_OF_RETIRES_DEFAULT,
-                       batchSize: Int = KuduSinkConfig.BATCH_SIZE_DEFAULT,
-                       schemaRegistryUrl: String)
+case class KuduSettings(routes: List[Config],
+                        topicTables : Map[String, String],
+                        allowAutoCreate: Map[String, Boolean],
+                        allowAutoEvolve: Map[String, Boolean],
+                        fieldsMap : Map[String, Map[String, String]],
+                        ignoreFields: Map[String, Set[String]],
+                        writeModeMap : Map[String, WriteModeEnum],
+                        errorPolicy: ErrorPolicy = new ThrowErrorPolicy,
+                        maxRetries: Int = KuduSinkConfig.NBR_OF_RETIRES_DEFAULT,
+                        batchSize: Int = KuduSinkConfig.BATCH_SIZE_DEFAULT,
+                        schemaRegistryUrl: String)
 
 object KuduSettings {
-  def apply(config: KuduSinkConfig, sinkTask: Boolean = true) : KuduSetting = {
+
+  def apply(config: KuduSinkConfig) : KuduSettings = {
+
     val raw = config.getString(KuduSinkConfig.EXPORT_ROUTE_QUERY)
-    require(raw != null && !raw.isEmpty,  s"No ${KuduSinkConfig.EXPORT_ROUTE_QUERY} provided!")
+    require(raw.nonEmpty,  s"No ${KuduSinkConfig.EXPORT_ROUTE_QUERY} provided!")
     val routes = raw.split(";").map(r => Config.parse(r)).toSet
     val errorPolicyE = ErrorPolicyEnum.withName(config.getString(KuduSinkConfig.ERROR_POLICY).toUpperCase)
     val errorPolicy = ErrorPolicy(errorPolicyE)
@@ -56,11 +56,11 @@ object KuduSettings {
       rm => (rm.getSource, rm.getFieldAlias.map(fa => (fa.getField,fa.getAlias)).toMap)
     ).toMap
 
-    val ignoreFields = routes.map(r => (r.getSource, r.getIgnoredField.asScala.toSet)).toMap
+    val ignoreFields = routes.map(r => (r.getSource, r.getIgnoredField.toSet)).toMap
     val writeModeMap = routes.map(r => (r.getSource, r.getWriteMode)).toMap
     val topicTables = routes.map(r => (r.getSource, r.getTarget)).toMap
 
-    KuduSetting(routes = routes.toList,
+    new KuduSettings(routes = routes.toList,
                 topicTables = topicTables,
                 allowAutoCreate = autoCreate,
                 allowAutoEvolve = autoEvolve,

--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/config/KuduSinkConfig.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/config/KuduSinkConfig.scala
@@ -14,7 +14,7 @@
   * limitations under the License.
   **/
 
-package com.datamountaineeer.streamreactor.connect.rethink.config
+package com.datamountaineer.streamreactor.connect.kudu.config
 
 import java.util
 
@@ -22,27 +22,18 @@ import org.apache.kafka.common.config.ConfigDef.{Importance, Type}
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 
 /**
-  * Created by andrew@datamountaineer.com on 24/03/16. 
+  * Created by andrew@datamountaineer.com on 22/02/16. 
   * stream-reactor
   */
-object ReThinkSinkConfig {
-  val RETHINK_HOST = "connect.rethink.sink.host"
-  val RETHINK_HOST_DOC = "Rethink server host."
-  val RETHINK_HOST_DEFAULT = "localhost"
-  val RETHINK_DB = "connect.rethink.sink.db"
-  val RETHINK_DB_DOC = "The reThink database to write to and create tables in."
-  val RETHINK_PORT = "connect.rethink.sink.port"
-  val RETHINK_PORT_DEFAULT = "28015"
-  val RETHINK_PORT_DOC = "Client port of rethink server to connect to."
 
-  val CONFLICT_ERROR = "ERROR"
-  val CONFLICT_REPLACE = "REPLACE"
-  val CONFLICT_UPDATE = "UPDATE"
+object KuduSinkConfig {
+  val KUDU_MASTER = "connect.kudu.master"
+  val KUDU_MASTER_DOC = "Kudu master cluster."
+  val KUDU_MASTER_DEFAULT = "localhost"
+  val EXPORT_ROUTE_QUERY = "connect.kudu.export.route.query"
+  val EXPORT_ROUTE_QUERY_DOC =  "KCQL expression describing field selection and routes."
 
-  val EXPORT_ROUTE_QUERY = "connect.rethink.sink.export.route.query"
-  val EXPORT_ROUTE_QUERY_DOC = ""
-
-  val ERROR_POLICY = "connect.rethink.size.error.policy"
+  val ERROR_POLICY = "connect.kudu.sink.error.policy"
   val ERROR_POLICY_DOC = "Specifies the action to be taken if an error occurs while inserting the data.\n" +
     "There are two available options: \n" + "NOOP - the error is swallowed \n" +
     "THROW - the error is allowed to propagate. \n" +
@@ -50,32 +41,35 @@ object ReThinkSinkConfig {
     "The error will be logged automatically"
   val ERROR_POLICY_DEFAULT = "THROW"
 
-  val ERROR_RETRY_INTERVAL = "connect.rethink.sink.retry.interval"
+  val ERROR_RETRY_INTERVAL = "connect.kudu.sink.retry.interval"
   val ERROR_RETRY_INTERVAL_DOC = "The time in milliseconds between retries."
   val ERROR_RETRY_INTERVAL_DEFAULT = "60000"
-  val NBR_OF_RETRIES = "connect.rethink.sink.max.retires"
+  val NBR_OF_RETRIES = "connect.kudu.max.retires"
   val NBR_OF_RETRIES_DOC = "The maximum number of times to try the write again."
   val NBR_OF_RETIRES_DEFAULT = 20
 
-  val BATCH_SIZE = "connect.rethink.sink.batch.size"
+  val BATCH_SIZE = "connect.kudu.sink.batch.size"
   val BATCH_SIZE_DOC = "Per topic the number of sink records to batch together and insert into Kudu"
   val BATCH_SIZE_DEFAULT = 1000
 
-  val SCHEMA_REGISTRY_URL = "connect.rethink.sink.schema.registry.url"
+  val SCHEMA_REGISTRY_URL = "connect.kudu.sink.schema.registry.url"
   val SCHEMA_REGISTRY_URL_DOC = "Url for the schema registry"
   val SCHEMA_REGISTRY_URL_DEFAULT = "http://localhost:8081"
 
+  val BUCKET_SIZE  = "connect.kudu.sink.bucket.size"
+  val BUCKET_SIZE_DOC = "The number of buckets to use for Auto Table creation. The distribution is set to use the Hash strategy"
+  val BUCKET_SIZE_DEFAULT = 10
+
   val config: ConfigDef = new ConfigDef()
-    .define(RETHINK_HOST, Type.STRING, RETHINK_HOST_DEFAULT, Importance.HIGH, RETHINK_HOST_DOC)
-    .define(RETHINK_DB, Type.STRING, Importance.HIGH, RETHINK_HOST_DOC)
-    .define(RETHINK_PORT, Type.INT, RETHINK_PORT_DEFAULT, Importance.MEDIUM, RETHINK_PORT_DOC)
+    .define(KUDU_MASTER, Type.STRING, KUDU_MASTER_DEFAULT, Importance.HIGH, KUDU_MASTER_DOC)
     .define(EXPORT_ROUTE_QUERY, Type.STRING, Importance.HIGH, EXPORT_ROUTE_QUERY)
     .define(ERROR_POLICY, Type.STRING, ERROR_POLICY_DEFAULT, Importance.HIGH, ERROR_POLICY_DOC)
     .define(ERROR_RETRY_INTERVAL, Type.INT, ERROR_RETRY_INTERVAL_DEFAULT, Importance.MEDIUM, ERROR_RETRY_INTERVAL_DOC)
     .define(NBR_OF_RETRIES, Type.INT, NBR_OF_RETIRES_DEFAULT, Importance.MEDIUM, NBR_OF_RETRIES_DOC)
     .define(BATCH_SIZE, Type.INT, BATCH_SIZE_DEFAULT, Importance.MEDIUM, BATCH_SIZE_DOC)
     .define(SCHEMA_REGISTRY_URL, Type.STRING, SCHEMA_REGISTRY_URL_DEFAULT ,Importance.HIGH, SCHEMA_REGISTRY_URL_DOC)
+    .define(BUCKET_SIZE, Type.INT, BUCKET_SIZE_DEFAULT, Importance.MEDIUM, BUCKET_SIZE_DOC)
 }
 
-case class ReThinkSinkConfig(props: util.Map[String, String])
-  extends AbstractConfig(ReThinkSinkConfig.config, props)
+class KuduSinkConfig(props: util.Map[String, String])
+  extends AbstractConfig(KuduSinkConfig.config, props)

--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/KuduSinkConnector.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/sink/KuduSinkConnector.scala
@@ -14,17 +14,17 @@
   * limitations under the License.
   **/
 
-package com.datamountaineer.streamreactor.connect.kudu
+package com.datamountaineer.streamreactor.connect.kudu.sink
 
 import java.util
 
-import com.datamountaineer.streamreactor.connect.config.KuduSinkConfig
+import com.datamountaineer.streamreactor.connect.kudu.config.KuduSinkConfig
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
 import org.apache.kafka.connect.sink.SinkConnector
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 /**
   * Created by andrew@datamountaineer.com on 22/02/16. 
@@ -47,7 +47,7 @@ class KuduSinkConnector extends SinkConnector with StrictLogging {
     * */
   override def taskConfigs(maxTasks: Int): util.List[util.Map[String, String]] = {
     logger.info(s"Setting task configurations for $maxTasks workers.")
-    (1 to maxTasks).map(c => configProps.get).toList.asJava
+    (1 to maxTasks).map(c => configProps.get).toList
   }
 
   /**

--- a/kafka-connect-kudu/src/test/java/com/datamountaineer/streamreactor/connect/kudu/services/RestApp.java
+++ b/kafka-connect-kudu/src/test/java/com/datamountaineer/streamreactor/connect/kudu/services/RestApp.java
@@ -1,21 +1,5 @@
 package com.datamountaineer.streamreactor.connect.kudu.services;
 
-/**
- * Copyright 2014 Confluent Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestBase.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestBase.scala
@@ -8,7 +8,7 @@ package com.datamountaineer.streamreactor.connect.kudu
 import java.nio.ByteBuffer
 import java.util
 
-import com.datamountaineer.streamreactor.connect.config.KuduSinkConfig
+import com.datamountaineer.streamreactor.connect.kudu.config.KuduSinkConfig
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestDbHandler.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestDbHandler.scala
@@ -1,8 +1,8 @@
 package com.datamountaineer.streamreactor.connect.kudu
 
-import com.datamountaineer.streamreactor.connect.KuduConverter
-import com.datamountaineer.streamreactor.connect.config.{KuduSettings, KuduSinkConfig}
+import com.datamountaineer.streamreactor.connect.kudu.config.{KuduSettings, KuduSinkConfig}
 import com.datamountaineer.streamreactor.connect.kudu.services.{EmbeddedSingleNodeKafkaCluster, RestApp}
+import com.datamountaineer.streamreactor.connect.kudu.sink.{CreateTableProps, DbHandler}
 import io.confluent.kafka.schemaregistry.client.rest.RestService
 import org.apache.curator.test.InstanceSpec
 import org.apache.kafka.connect.errors.ConnectException
@@ -114,7 +114,7 @@ class TestDbHandler extends TestBase with MockitoSugar with KuduConverter {
     val config = new KuduSinkConfig(getConfigAutoCreate(9999))
     val settings = KuduSettings(config)
     val cache = DbHandler.buildTableCache(settings, client)
-    cache.get(TOPIC).get shouldBe table
+    cache(TOPIC) shouldBe table
   }
 
   "Should throw table not found when building insert cache" in {

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduConverter.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduConverter.scala
@@ -1,11 +1,10 @@
 package com.datamountaineer.streamreactor.connect.kudu
 
-import com.datamountaineer.streamreactor.connect.KuduConverter
 import com.datamountaineer.streamreactor.connect.schemas.ConverterUtil
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Field
 import org.codehaus.jackson.node.NullNode
-import org.kududb.client.{Insert, KuduTable, Upsert}
+import org.kududb.client.{KuduTable, Upsert}
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduSink.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduSink.scala
@@ -1,5 +1,6 @@
 package com.datamountaineer.streamreactor.connect.kudu
 
+import com.datamountaineer.streamreactor.connect.kudu.sink.KuduSinkTask
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTaskContext}
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduSinkConnector.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduSinkConnector.scala
@@ -1,8 +1,11 @@
 package com.datamountaineer.streamreactor.connect.kudu
 
-import com.datamountaineer.streamreactor.connect.config.KuduSinkConfig
+import com.datamountaineer.streamreactor.connect.kudu.config.KuduSinkConfig
+import com.datamountaineer.streamreactor.connect.kudu.sink.{KuduSinkConnector, KuduSinkTask}
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
+
+
 /**
   * Created by andrew@datamountaineer.com on 24/02/16. 
   * stream-reactor
@@ -13,7 +16,7 @@ class TestKuduSinkConnector extends TestBase {
     val connector = new KuduSinkConnector()
     connector.start(config)
     val taskConfigs = connector.taskConfigs(1)
-    taskConfigs.asScala.head.get(KuduSinkConfig.KUDU_MASTER) shouldBe KUDU_MASTER
+    taskConfigs.head.get(KuduSinkConfig.KUDU_MASTER) shouldBe KUDU_MASTER
     taskConfigs.size() shouldBe 1
     connector.taskClass() shouldBe classOf[KuduSinkTask]
     connector.stop()

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduSourceConfig.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduSourceConfig.scala
@@ -1,7 +1,6 @@
 package com.datamountaineer.streamreactor.connect.kudu
 
-import com.datamountaineer.streamreactor.connect.config.KuduSinkConfig
-
+import com.datamountaineer.streamreactor.connect.kudu.config.KuduSinkConfig
 
 /**
   * Created by andrew@datamountaineer.com on 24/02/16. 

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduWriter.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduWriter.scala
@@ -1,14 +1,14 @@
 package com.datamountaineer.streamreactor.connect.kudu
 
-import com.datamountaineer.streamreactor.connect.KuduConverter
-import com.datamountaineer.streamreactor.connect.config.{KuduSettings, KuduSinkConfig}
+import com.datamountaineer.streamreactor.connect.kudu.config.{KuduSettings, KuduSinkConfig}
+import com.datamountaineer.streamreactor.connect.kudu.sink.KuduWriter
 import org.apache.kafka.connect.errors.RetriableException
 import org.kududb.client._
 import org.mockito.Matchers.{any, eq => mockEq}
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 /**
   * Created by andrew@datamountaineer.com on 04/03/16. 
@@ -127,7 +127,7 @@ class TestKuduWriter extends TestBase with KuduConverter with MockitoSugar {
       when(resp.hasRowError).thenReturn(true)
       when(errorRow.toString).thenReturn("Test error string")
       when(resp.getRowError).thenReturn(errorRow)
-      when(kuduSession.flush()).thenReturn(List(resp).asJava)
+      when(kuduSession.flush()).thenReturn(List(resp))
 
       val writer = new KuduWriter(client, settings)
 

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkConnector.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkConnector.scala
@@ -35,8 +35,8 @@ import scala.collection.JavaConverters._
   **/
 class RedisSinkConnector extends SinkConnector with StrictLogging {
   //???
-  private var configProps: util.Map[String, String] = null
-  private var connConfigDef : Option[ConfigDef] = null
+  private var configProps: util.Map[String, String] = _
+  private var connConfigDef : Option[ConfigDef] = _
 
   /**
     * States which SinkTask class to use

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTask.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/RedisSinkTask.scala
@@ -24,10 +24,10 @@ import com.datamountaineer.streamreactor.connect.redis.sink.writer.{RedisDbWrite
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTask}
 
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
 
 /**
   * <h1>RedisSinkTask</h1>
@@ -64,6 +64,9 @@ class RedisSinkTask extends SinkTask with StrictLogging {
     RedisSinkConfig.config.parse(props)
     val sinkConfig = new RedisSinkConfig(props)
     val settings = RedisSinkSettings(sinkConfig)
+
+    val assigned = context.assignment().map(a => a.topic()).toList
+    if (assigned.isEmpty) throw new ConnectException("No topics have been assigned to this task!")
 
     //if error policy is retry set retry interval
     if (settings.errorPolicy.equals(ErrorPolicyEnum.RETRY)) {

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkConfig.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkConfig.scala
@@ -42,7 +42,7 @@ object RedisSinkConfig {
     """.stripMargin
 
   val EXPORT_ROUTE_QUERY = "connect.hbase.export.route.query"
-  val EXPORT_ROUTE_QUERY_DOC = ""
+  val EXPORT_ROUTE_QUERY_DOC = "KCQL expression describing field selection and routes."
 
   val ERROR_POLICY = "connect.hbase.error.policy"
   val ERROR_POLICY_DOC = "Specifies the action to be taken if an error occurs while inserting the data.\n" +

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettings.scala
@@ -20,7 +20,6 @@ import com.datamountaineer.connector.config.Config
 import com.datamountaineer.streamreactor.connect.errors.{ErrorPolicy, ErrorPolicyEnum, ThrowErrorPolicy}
 import com.datamountaineer.streamreactor.connect.redis.sink.config.RedisSinkConfig._
 import com.datamountaineer.streamreactor.connect.rowkeys._
-import com.datamountaineer.streamreactor.connect.schemas.StructFieldsExtractor
 import org.apache.kafka.common.config.ConfigException
 
 import scala.collection.JavaConversions._

--- a/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisDbWriter.scala
+++ b/kafka-connect-redis/src/main/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisDbWriter.scala
@@ -23,6 +23,7 @@ import com.datamountaineer.streamreactor.connect.sink._
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.sink.SinkRecord
 import redis.clients.jedis.Jedis
+
 import scala.util.Try
 
 /**
@@ -67,9 +68,9 @@ case class RedisDbWriter(sinkSettings: RedisSinkSettings) extends DbWriter with 
       val t = Try(
         {
           sinkRecords.foreach { record =>
-            val keyBuilder = rowKeyMap.get(topic).get
-            val fields = sinkSettings.fields.get(record.topic()).get
-            val ignored = sinkSettings.ignoreFields.get(record.topic()).get
+            val keyBuilder = rowKeyMap(topic)
+            val fields = sinkSettings.fields(record.topic())
+            val ignored = sinkSettings.ignoreFields(record.topic())
             val extracted = convert(record, fields, ignored)
             val key = keyBuilder.build(extracted)
             val payload = convertValueToJson(extracted).toString

--- a/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettingsTest.scala
+++ b/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/config/RedisSinkSettingsTest.scala
@@ -42,7 +42,7 @@ class RedisSinkSettingsTest extends WordSpec with Matchers with MockitoSugar {
     val settings = RedisSinkSettings(config)
     val route = settings.routes.head
 
-    settings.rowKeyModeMap.get(TABLE_NAME_RAW).get.isInstanceOf[StringStructFieldsStringKeyBuilder] shouldBe true
+    settings.rowKeyModeMap(TABLE_NAME_RAW).isInstanceOf[StringStructFieldsStringKeyBuilder] shouldBe true
 
     route.isIncludeAllFields shouldBe true
     route.getTarget shouldBe TABLE_NAME_RAW
@@ -60,7 +60,7 @@ class RedisSinkSettingsTest extends WordSpec with Matchers with MockitoSugar {
 
     val settings = RedisSinkSettings(config)
 
-    settings.rowKeyModeMap.get(TABLE_NAME_RAW).get.isInstanceOf[StringGenericRowKeyBuilder] shouldBe true
+    settings.rowKeyModeMap(TABLE_NAME_RAW).isInstanceOf[StringGenericRowKeyBuilder] shouldBe true
     val route = settings.routes.head
 
     route.isIncludeAllFields shouldBe true
@@ -81,7 +81,7 @@ class RedisSinkSettingsTest extends WordSpec with Matchers with MockitoSugar {
     val route = settings.routes.head
     val fields = route.getFieldAlias.asScala.toList
 
-    settings.rowKeyModeMap.get(TABLE_NAME_RAW).get.isInstanceOf[StringGenericRowKeyBuilder] shouldBe true
+    settings.rowKeyModeMap(TABLE_NAME_RAW).isInstanceOf[StringGenericRowKeyBuilder] shouldBe true
 
     route.isIncludeAllFields shouldBe false
     route.getSource shouldBe TABLE_NAME_RAW
@@ -105,7 +105,7 @@ class RedisSinkSettingsTest extends WordSpec with Matchers with MockitoSugar {
     val route = settings.routes.head
     val fields = route.getFieldAlias.asScala.toList
 
-    settings.rowKeyModeMap.get(TABLE_NAME_RAW).get.isInstanceOf[StringStructFieldsStringKeyBuilder] shouldBe true
+    settings.rowKeyModeMap(TABLE_NAME_RAW).isInstanceOf[StringStructFieldsStringKeyBuilder] shouldBe true
 
     route.isIncludeAllFields shouldBe false
     route.getSource shouldBe TABLE_NAME_RAW

--- a/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisDbWriterTest.scala
+++ b/kafka-connect-redis/src/test/scala/com/datamountaineer/streamreactor/connect/redis/sink/writer/RedisDbWriterTest.scala
@@ -62,16 +62,16 @@ class RedisDbWriterTest extends WordSpec with Matchers with BeforeAndAfterAll wi
       val1 should not be null
 
       val map1 = gson.fromJson(val1, classOf[java.util.Map[String, AnyRef]]).asScala
-      map1.get("firstName").get.toString shouldBe "Alex"
-      map1.get("age").get.toString shouldBe "30.0" //it gets back a java double!?
+      map1("firstName").toString shouldBe "Alex"
+      map1("age").toString shouldBe "30.0" //it gets back a java double!?
 
       val val2 = jedis.get(s"$TOPIC|1|1")
       val2 should not be null
 
       val map2 = gson.fromJson(val2, classOf[java.util.Map[String, AnyRef]]).asScala
-      map2.get("firstName").get shouldBe "Mara"
-      map2.get("age").get.toString shouldBe "22.0"
-      map2.get("threshold").get.toString shouldBe "12.4"
+      map2("firstName") shouldBe "Mara"
+      map2("age").toString shouldBe "22.0"
+      map2("threshold").toString shouldBe "12.4"
     }
 
     "write the given SinkRecords to the redis database with mode FIELDS" in {
@@ -110,16 +110,16 @@ class RedisDbWriterTest extends WordSpec with Matchers with BeforeAndAfterAll wi
       val1 should not be null
 
       val map1 = gson.fromJson(val1, classOf[java.util.Map[String, AnyRef]]).asScala
-      map1.get("firstName").get.toString shouldBe "Alex"
-      map1.get("age").get.toString shouldBe "30.0" //it gets back a java double!?
+      map1("firstName").toString shouldBe "Alex"
+      map1("age").toString shouldBe "30.0" //it gets back a java double!?
 
       val val2 = jedis.get("Mara")
       val2 should not be null
 
       val map2 = gson.fromJson(val2, classOf[java.util.Map[String, AnyRef]]).asScala
-      map2.get("firstName").get shouldBe "Mara"
-      map2.get("age").get.toString shouldBe "22.0"
-      map2.get("threshold").get.toString shouldBe "12.4"
+      map2("firstName") shouldBe "Mara"
+      map2("age").toString shouldBe "22.0"
+      map2("threshold").toString shouldBe "12.4"
     }
   }
 }

--- a/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/config/ReThinkSettings.scala
+++ b/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/config/ReThinkSettings.scala
@@ -21,7 +21,6 @@ import com.datamountaineer.streamreactor.connect.errors.{ErrorPolicy, ErrorPolic
 import org.apache.kafka.connect.errors.ConnectException
 
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
 
 /**
   * Created by andrew@datamountaineer.com on 13/05/16.
@@ -47,7 +46,7 @@ object ReThinkSettings {
 
     //only allow on primary key for rethink.
     routes
-      .filter(r => r.getPrimaryKeys.asScala.size > 1)
+      .filter(r => r.getPrimaryKeys.size > 1)
       .foreach(r => new ConnectException(s"More than one primary key found in ${ReThinkSinkConfig.EXPORT_ROUTE_QUERY}." +
         s" Only one field can be set."))
 
@@ -82,7 +81,7 @@ object ReThinkSettings {
           .map({ case (f, a) => f })
             .toSet)
     })
-    val ignoreFields = routes.map(rm => (rm.getSource, rm.getIgnoredField.asScala.toSet)).toMap
+    val ignoreFields = routes.map(rm => (rm.getSource, rm.getIgnoredField.toSet)).toMap
 
     ReThinkSetting(db, routes, topicTableMap, fieldMap, ignoreFields ,pks, conflictMap, errorPolicy, maxRetries, batchSize)
   }

--- a/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/config/ReThinkSinkConfig.scala
+++ b/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/config/ReThinkSinkConfig.scala
@@ -14,7 +14,7 @@
   * limitations under the License.
   **/
 
-package com.datamountaineer.streamreactor.connect.config
+package com.datamountaineeer.streamreactor.connect.rethink.config
 
 import java.util
 
@@ -22,18 +22,27 @@ import org.apache.kafka.common.config.ConfigDef.{Importance, Type}
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 
 /**
-  * Created by andrew@datamountaineer.com on 22/02/16. 
+  * Created by andrew@datamountaineer.com on 24/03/16. 
   * stream-reactor
   */
+object ReThinkSinkConfig {
+  val RETHINK_HOST = "connect.rethink.sink.host"
+  val RETHINK_HOST_DOC = "Rethink server host."
+  val RETHINK_HOST_DEFAULT = "localhost"
+  val RETHINK_DB = "connect.rethink.sink.db"
+  val RETHINK_DB_DOC = "The reThink database to write to and create tables in."
+  val RETHINK_PORT = "connect.rethink.sink.port"
+  val RETHINK_PORT_DEFAULT = "28015"
+  val RETHINK_PORT_DOC = "Client port of rethink server to connect to."
 
-object KuduSinkConfig {
-  val KUDU_MASTER = "connect.kudu.master"
-  val KUDU_MASTER_DOC = "Kudu master cluster."
-  val KUDU_MASTER_DEFAULT = "localhost"
-  val EXPORT_ROUTE_QUERY = "connect.kudu.export.route.query"
-  val EXPORT_ROUTE_QUERY_DOC = ""
+  val CONFLICT_ERROR = "ERROR"
+  val CONFLICT_REPLACE = "REPLACE"
+  val CONFLICT_UPDATE = "UPDATE"
 
-  val ERROR_POLICY = "connect.kudu.sink.error.policy"
+  val EXPORT_ROUTE_QUERY = "connect.rethink.sink.export.route.query"
+  val EXPORT_ROUTE_QUERY_DOC = "KCQL expression describing field selection and routes."
+
+  val ERROR_POLICY = "connect.rethink.size.error.policy"
   val ERROR_POLICY_DOC = "Specifies the action to be taken if an error occurs while inserting the data.\n" +
     "There are two available options: \n" + "NOOP - the error is swallowed \n" +
     "THROW - the error is allowed to propagate. \n" +
@@ -41,35 +50,32 @@ object KuduSinkConfig {
     "The error will be logged automatically"
   val ERROR_POLICY_DEFAULT = "THROW"
 
-  val ERROR_RETRY_INTERVAL = "connect.kudu.sink.retry.interval"
+  val ERROR_RETRY_INTERVAL = "connect.rethink.sink.retry.interval"
   val ERROR_RETRY_INTERVAL_DOC = "The time in milliseconds between retries."
   val ERROR_RETRY_INTERVAL_DEFAULT = "60000"
-  val NBR_OF_RETRIES = "connect.kudu.max.retires"
+  val NBR_OF_RETRIES = "connect.rethink.sink.max.retires"
   val NBR_OF_RETRIES_DOC = "The maximum number of times to try the write again."
   val NBR_OF_RETIRES_DEFAULT = 20
 
-  val BATCH_SIZE = "connect.kudu.sink.batch.size"
+  val BATCH_SIZE = "connect.rethink.sink.batch.size"
   val BATCH_SIZE_DOC = "Per topic the number of sink records to batch together and insert into Kudu"
   val BATCH_SIZE_DEFAULT = 1000
 
-  val SCHEMA_REGISTRY_URL = "connect.kudu.sink.schema.registry.url"
+  val SCHEMA_REGISTRY_URL = "connect.rethink.sink.schema.registry.url"
   val SCHEMA_REGISTRY_URL_DOC = "Url for the schema registry"
   val SCHEMA_REGISTRY_URL_DEFAULT = "http://localhost:8081"
 
-  val BUCKET_SIZE  = "connect.kudu.sink.bucket.size"
-  val BUCKET_SIZE_DOC = "The number of buckets to use for Auto Table creation. The distribution is set to use the Hash strategy"
-  val BUCKET_SIZE_DEFAULT = 10
-
   val config: ConfigDef = new ConfigDef()
-    .define(KUDU_MASTER, Type.STRING, KUDU_MASTER_DEFAULT, Importance.HIGH, KUDU_MASTER_DOC)
+    .define(RETHINK_HOST, Type.STRING, RETHINK_HOST_DEFAULT, Importance.HIGH, RETHINK_HOST_DOC)
+    .define(RETHINK_DB, Type.STRING, Importance.HIGH, RETHINK_HOST_DOC)
+    .define(RETHINK_PORT, Type.INT, RETHINK_PORT_DEFAULT, Importance.MEDIUM, RETHINK_PORT_DOC)
     .define(EXPORT_ROUTE_QUERY, Type.STRING, Importance.HIGH, EXPORT_ROUTE_QUERY)
     .define(ERROR_POLICY, Type.STRING, ERROR_POLICY_DEFAULT, Importance.HIGH, ERROR_POLICY_DOC)
     .define(ERROR_RETRY_INTERVAL, Type.INT, ERROR_RETRY_INTERVAL_DEFAULT, Importance.MEDIUM, ERROR_RETRY_INTERVAL_DOC)
     .define(NBR_OF_RETRIES, Type.INT, NBR_OF_RETIRES_DEFAULT, Importance.MEDIUM, NBR_OF_RETRIES_DOC)
     .define(BATCH_SIZE, Type.INT, BATCH_SIZE_DEFAULT, Importance.MEDIUM, BATCH_SIZE_DOC)
     .define(SCHEMA_REGISTRY_URL, Type.STRING, SCHEMA_REGISTRY_URL_DEFAULT ,Importance.HIGH, SCHEMA_REGISTRY_URL_DOC)
-    .define(BUCKET_SIZE, Type.INT, BUCKET_SIZE_DEFAULT, Importance.MEDIUM, BUCKET_SIZE_DOC)
 }
 
-class KuduSinkConfig(props: util.Map[String, String])
-  extends AbstractConfig(KuduSinkConfig.config, props)
+case class ReThinkSinkConfig(props: util.Map[String, String])
+  extends AbstractConfig(ReThinkSinkConfig.config, props)

--- a/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/sink/ReThinkSinkConnector.scala
+++ b/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/sink/ReThinkSinkConnector.scala
@@ -32,7 +32,7 @@ import scala.collection.JavaConverters._
   * stream-reactor
   */
 class ReThinkSinkConnector extends SinkConnector with StrictLogging {
-  private var configProps: util.Map[String, String] = null
+  private var configProps: util.Map[String, String] = _
   private var connConfigDef : Option[ConfigDef] = None
 
   /**

--- a/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/sink/ReThinkSinkConverter.scala
+++ b/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/sink/ReThinkSinkConverter.scala
@@ -22,11 +22,11 @@ import com.rethinkdb.model.MapObject
 import com.rethinkdb.net.Connection
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.data.Schema.Type
-import org.apache.kafka.connect.data.{Field, Schema, Struct}
+import org.apache.kafka.connect.data.{Field, Struct}
 import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.sink.SinkRecord
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 /**
   * Created by andrew@datamountaineer.com on 24/06/16. 
@@ -58,9 +58,9 @@ object ReThinkSinkConverter extends StrictLogging {
 
         val create = rethink.db(setting.db).tableCreate(r.getTarget)
         //set primary keys if we have them
-        val pk = r.getPrimaryKeys.asScala.toSet
+        val pk = r.getPrimaryKeys.toSet
         val pkName = if (pk.isEmpty) "id" else pk.head
-        logger.info(s"Setting primary as first field found: ${pkName}")
+        logger.info(s"Setting primary as first field found: $pkName")
         create.optArg("primary_key", pkName)
         create.run(conn)
         logger.info(s"Table ${r.getTarget} created.")
@@ -88,7 +88,7 @@ object ReThinkSinkConverter extends StrictLogging {
     }
 
     //add the sinkrecord fields to the MapObject
-    fields.asScala.map(f => buildField(rethink, f, s, mo))
+    fields.map(f => buildField(rethink, f, s, mo))
     mo
   }
 
@@ -108,7 +108,7 @@ object ReThinkSinkConverter extends StrictLogging {
       case Type.STRUCT =>
         val nested = struct.getStruct(field.name())
         val schema = nested.schema()
-        val fields = schema.fields().asScala
+        val fields = schema.fields()
         val mo = rethink.hashMap()
         fields.map(f => buildField(rethink, f, nested, mo))
         hm.`with`(field.name, mo)

--- a/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/sink/ReThinkSinkTask.scala
+++ b/kafka-connect-rethink/src/main/scala/com/datamountaineeer/streamreactor/connect/rethink/sink/ReThinkSinkTask.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.connect.sink.{SinkRecord, SinkTask}
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 /**
   * Created by andrew@datamountaineer.com on 24/03/16. 
@@ -54,7 +54,7 @@ class ReThinkSinkTask extends SinkTask with StrictLogging {
       """.stripMargin)
 
     val sinkConfig = ReThinkSinkConfig(props)
-    writer = Some(ReThinkWriter(config = sinkConfig))
+    writer = Some(ReThinkWriter(config = sinkConfig, context = context))
   }
 
   /**
@@ -62,7 +62,7 @@ class ReThinkSinkTask extends SinkTask with StrictLogging {
     * */
   override def put(records: util.Collection[SinkRecord]): Unit = {
     require(writer.nonEmpty, "Writer is not set!")
-    writer.foreach(w => w.write(records.asScala.toList))
+    writer.foreach(w => w.write(records.toList))
   }
 
   /**

--- a/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/TestBase.scala
+++ b/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/TestBase.scala
@@ -8,8 +8,8 @@ import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 
-import scala.collection.mutable
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 /**
   * Created by andrew@datamountaineer.com on 21/06/16. 

--- a/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/config/TestReThinkSinkSettings.scala
+++ b/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/config/TestReThinkSinkSettings.scala
@@ -6,6 +6,7 @@ import com.datamountaineer.streamreactor.connect.rethink.TestBase
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
+
 import scala.collection.JavaConverters._
 
 /**
@@ -22,7 +23,7 @@ class TestReThinkSinkSettings extends TestBase with MockitoSugar {
     routes.getSource shouldBe TOPIC
     routes.getTarget shouldBe TABLE
     routes.getWriteMode shouldBe WriteModeEnum.INSERT
-    val conflict = settings.conflictPolicy.get(TABLE).get
+    val conflict = settings.conflictPolicy(TABLE)
     conflict shouldBe ReThinkSinkConfig.CONFLICT_ERROR
     routes.isIncludeAllFields shouldBe true
   }
@@ -36,7 +37,7 @@ class TestReThinkSinkSettings extends TestBase with MockitoSugar {
     routes.getSource shouldBe TOPIC
     routes.getTarget shouldBe TABLE
     routes.getWriteMode shouldBe WriteModeEnum.UPSERT
-    val conflict = settings.conflictPolicy.get(TABLE).get
+    val conflict = settings.conflictPolicy(TABLE)
     conflict shouldBe ReThinkSinkConfig.CONFLICT_REPLACE
     routes.isIncludeAllFields shouldBe false
     val fields = routes.getFieldAlias.asScala.toList

--- a/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/sink/TestReThinkSinkConnector.scala
+++ b/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/sink/TestReThinkSinkConnector.scala
@@ -3,6 +3,7 @@ package com.datamountaineer.streamreactor.connect.rethink.sink
 import com.datamountaineeer.streamreactor.connect.rethink.config.ReThinkSinkConfig
 import com.datamountaineeer.streamreactor.connect.rethink.sink.{ReThinkSinkConnector, ReThinkSinkTask}
 import com.datamountaineer.streamreactor.connect.rethink.TestBase
+
 import scala.collection.JavaConverters._
 
 /**

--- a/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/sink/TestReThinkSinkConverter.scala
+++ b/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/sink/TestReThinkSinkConverter.scala
@@ -9,9 +9,9 @@ import com.rethinkdb.model.MapObject
 import com.rethinkdb.net.Connection
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.sink.SinkRecord
+import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
-import org.mockito.Matchers._
 
 import scala.collection.JavaConverters._
 

--- a/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/sink/TestReThinkWriter.scala
+++ b/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/sink/TestReThinkWriter.scala
@@ -10,9 +10,9 @@ import com.rethinkdb.model.MapObject
 import com.rethinkdb.net.Connection
 import org.apache.kafka.connect.errors.RetriableException
 import org.apache.kafka.connect.sink.SinkTaskContext
+import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
-import org.mockito.Matchers._
 
 import scala.collection.JavaConverters._
 
@@ -28,7 +28,7 @@ class TestReThinkWriter extends TestBase with MockitoSugar with ConverterUtil {
     val settings = ReThinkSettings(config)
     val records = getTestRecords
 
-    val conflict = settings.conflictPolicy.get(TABLE).get
+    val conflict = settings.conflictPolicy(TABLE)
 
     val r = mock[RethinkDB]
     val connBuilder = mock[Connection.Builder]
@@ -68,7 +68,7 @@ class TestReThinkWriter extends TestBase with MockitoSugar with ConverterUtil {
     val config = new ReThinkSinkConfig(getPropsUpsertSelectRetry)
     val settings = ReThinkSettings(config)
     val records = getTestRecords
-    val conflict = settings.conflictPolicy.get(TABLE).get
+    val conflict = settings.conflictPolicy(TABLE)
 
     val r = mock[RethinkDB]
     val connBuilder = mock[Connection.Builder]

--- a/kafka-connect-yahoo/build.gradle
+++ b/kafka-connect-yahoo/build.gradle
@@ -1,0 +1,23 @@
+project(":kafka-connect-yahoo") {
+
+    ext {
+        snappyVersion = "1.1.2.1"
+        yahooVersion = "1.3.0"
+    }
+
+    test {
+        //for casssandra unit, add to classpath the cassandra yaml files
+        classpath = project.sourceSets.test.runtimeClasspath + files("${projectDir}/src/test/resources")
+        classpath = project.sourceSets.test.runtimeClasspath + files("${projectDir.getCanonicalPath()}/src/test/resources/log4j.properties")
+        systemProperty 'log4j.configuration', "file:${projectDir.canonicalPath}/src/test/resources/log4j.properties"
+        //dependsOn copyResources
+    }
+
+    dependencies {
+        compile "com.datamountaineer:kafka-connect-common:$dataMountaineerCommonVersion"
+        compile "com.yahoofinance-api:YahooFinanceAPI:$yahooVersion"
+        compile 'joda-time:joda-time:2.9.4'
+        testCompile "com.google.code.findbugs:jsr305:1.3.9"
+
+    }
+}

--- a/kafka-connect-yahoo/src/main/resources/log4j.properties
+++ b/kafka-connect-yahoo/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+# suppress inspection "UnusedProperty" for whole file
+log4j.rootLogger=INFO,stdout
+
+#stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.conversionPattern=%d{ISO8601} %-5p [%t] [%c] [%M:%L] %m%n

--- a/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/config/DistributeConfigurationFn.scala
+++ b/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/config/DistributeConfigurationFn.scala
@@ -1,0 +1,47 @@
+package com.datamountaineer.streamreactor.connect.yahoo.config
+
+object DistributeConfigurationFn {
+  def apply(partitions: Int, map: Map[String, String]): Seq[Map[String, String]] = {
+    if (partitions <= 1) Seq(map)
+    else {
+      val stocks = map.get(YahooConfigConstants.STOCKS)
+        .map { v => v.split(',').map(s => s.trim).toVector }
+        .getOrElse(Vector.empty)
+
+
+      val fx = map.get(YahooConfigConstants.FX).map {
+        _.split(',').map(_.trim).toVector
+      }.getOrElse(Vector.empty)
+
+
+      val itemsPerPartitionStocks = (stocks.size - stocks.size % partitions) / partitions + (if (stocks.size % partitions != 0) 1 else 0)
+      val itemsPerPartitionFx = (fx.size - fx.size % partitions) / partitions + (if (fx.size % partitions != 0) 1 else 0)
+
+      val stocksGroups = if (stocks.nonEmpty) stocks.grouped(itemsPerPartitionStocks).toVector else Vector.empty
+      val fxGroups = if (fx.nonEmpty) fx.grouped(itemsPerPartitionFx).toVector else Vector.empty
+
+      val min = math.min(stocksGroups.size, fxGroups.size)
+      val max = math.max(stocksGroups.size, fxGroups.size)
+
+      val r1 = (0 until min).map { i =>
+        var m = stocksGroups.headOption.foldLeft(map) { case (m, _) =>
+          m + (YahooConfigConstants.STOCKS -> stocksGroups(i).mkString(","))
+        }
+
+        fxGroups.headOption.foldLeft(m) { case (m, _) =>
+          m + (YahooConfigConstants.FX -> fxGroups(i).mkString(","))
+        }
+      }
+
+      val r2 = (min until math.min(max, stocksGroups.size)).map { i =>
+        map - YahooConfigConstants.FX + (YahooConfigConstants.STOCKS -> stocksGroups(i).mkString(","))
+      }
+
+      val r3 = (min until math.min(max, fxGroups.size)).map { i =>
+        map - YahooConfigConstants.STOCKS + (YahooConfigConstants.FX -> fxGroups(i).mkString(","))
+      }
+
+      r1 ++ r2 ++ r3
+    }
+  }
+}

--- a/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/config/YahooConfigConstants.scala
+++ b/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/config/YahooConfigConstants.scala
@@ -1,0 +1,48 @@
+/**
+  * Copyright 2016 Datamountaineer.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
+
+package com.datamountaineer.streamreactor.connect.yahoo.config
+
+/**
+  * Holds the constants used in the config.
+  **/
+
+object YahooConfigConstants {
+  val DEFAULT_POLL_INTERVAL = 60000L
+  //1 minute
+  val Poll_Interval_Doc = "The polling interval between queries against yahoo webservice."
+  val DEFAULT_ERROR_POLICY = "THROW"
+  val DEFAULT_RETRIES = 10
+
+  val POLL_INTERVAL = "connect.yahoo,source.poll.interval"
+  val POLL_INTERVAL_DOC = "Specifies how often if polls Yahoo services for new data"
+
+  val STOCKS = "connect.yahoo.source.stocks.subscriptions"
+  val STOCKS_DOC = "Sets the financials stocks to query from Yahoo finance."
+  val STOCKS_KAFKA_TOPIC = "connect.yahoo.source.stocks.topic"
+  val STOCKS_KAFKA_TOPIC_DOC = "Specifies which kafka topic will receive the the stock informations"
+
+  val FX = "connect.yahoo.source.fx.subscriptions"
+  val FX_DOC = "Sets the foreign exchange values to retrieve from Yahoo finance"
+  val FX_KAFKA_TOPIC = "connect.yahoo.source.fx.topic"
+  val FX_KAFKA_TOPIC_DOC = "Specifies the target kafka topic to send the FX values to"
+
+  val ERROR_POLICY = "connect.yahoo.source.error.policy"
+  val ERROR_POLICY_DOC = "Sets the error handling approach. Available options are THROW and NOOP"
+
+  val NBR_OF_RETRIES = "connect.yahoo.source.retries"
+  val NBR_OF_RETRIES_DOC = ""
+}

--- a/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/config/YahooSettings.scala
+++ b/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/config/YahooSettings.scala
@@ -1,0 +1,61 @@
+/**
+  * Copyright 2016 Datamountaineer.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
+
+package com.datamountaineer.streamreactor.connect.yahoo.config
+
+import com.datamountaineer.streamreactor.connect.errors.{ErrorPolicy, ErrorPolicyEnum, ThrowErrorPolicy}
+import io.confluent.common.config.{AbstractConfig, ConfigException}
+
+
+case class YahooSourceSetting(stocks: Set[String],
+                              stocksKafkaTopic: Option[String],
+                              fxQuotes: Set[String],
+                              fxKafkaTopic: Option[String],
+                              config: AbstractConfig,
+                              pollInterval: Long = YahooConfigConstants.DEFAULT_POLL_INTERVAL,
+                              errorPolicy: ErrorPolicy = new ThrowErrorPolicy,
+                              taskRetires: Int = 10)
+
+object YahooSettings {
+  def apply(config: AbstractConfig) = {
+
+    val stocks = Option(config.getString(YahooConfigConstants.STOCKS))
+      .map(v => v.split(",").map(_.trim.toUpperCase()).toSet)
+      .getOrElse(Set.empty)
+
+    val topicStocks = config.getString(YahooConfigConstants.STOCKS_KAFKA_TOPIC)
+    if ((topicStocks == null && stocks.nonEmpty) || (topicStocks != null && stocks.isEmpty)) {
+      throw new ConfigException(s"${YahooConfigConstants.STOCKS} and ${YahooConfigConstants.STOCKS_KAFKA_TOPIC} " +
+        s"should be both set or left out")
+    }
+
+    val fx = Option(config.getString(YahooConfigConstants.FX)).map(v => v.split(",")
+      .map(_.trim.toUpperCase()).toSet)
+      .getOrElse(Set.empty)
+
+    val topicFx = config.getString(YahooConfigConstants.FX_KAFKA_TOPIC)
+    if ((topicFx == null && fx.nonEmpty) || (topicFx != null && fx.isEmpty)) {
+      throw new ConfigException(s"${YahooConfigConstants.FX} and ${YahooConfigConstants.FX_KAFKA_TOPIC} should be both" +
+        s"set or left out")
+    }
+
+    val pollInterval = config.getLong(YahooConfigConstants.POLL_INTERVAL)
+    val errorPolicyValue = ErrorPolicyEnum.withName(config.getString(YahooConfigConstants.ERROR_POLICY).toUpperCase)
+    val errorPolicy = ErrorPolicy(errorPolicyValue)
+
+    new YahooSourceSetting(stocks, Option(topicStocks), fx, Option(topicFx), config, pollInterval, errorPolicy)
+  }
+}

--- a/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/config/YahooSourceConfig.scala
+++ b/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/config/YahooSourceConfig.scala
@@ -1,0 +1,75 @@
+/**
+  * Copyright 2016 Datamountaineer.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
+
+package com.datamountaineer.streamreactor.connect.yahoo.config
+
+import io.confluent.common.config.ConfigDef
+import io.confluent.common.config.ConfigDef.{Importance, Type}
+
+
+/**
+  * Holds the base configuration.
+  **/
+trait YahooSourceConfig {
+
+  val configDef: ConfigDef = new ConfigDef()
+    .define(YahooConfigConstants.FX,
+      Type.STRING,
+      Importance.HIGH,
+      YahooConfigConstants.FX_DOC)
+
+    .define(YahooConfigConstants.FX_KAFKA_TOPIC,
+      Type.STRING,
+      Importance.HIGH,
+      YahooConfigConstants.FX_KAFKA_TOPIC_DOC)
+
+    .define(YahooConfigConstants.STOCKS,
+      Type.STRING,
+      Importance.HIGH,
+      YahooConfigConstants.STOCKS_DOC)
+
+    .define(YahooConfigConstants.STOCKS_KAFKA_TOPIC,
+      Type.STRING,
+      Importance.HIGH,
+      YahooConfigConstants.STOCKS_KAFKA_TOPIC_DOC)
+
+    .define(YahooConfigConstants.ERROR_POLICY,
+      Type.STRING,
+      YahooConfigConstants.DEFAULT_ERROR_POLICY,
+      Importance.HIGH,
+      YahooConfigConstants.ERROR_POLICY_DOC
+    )
+
+    .define(YahooConfigConstants.NBR_OF_RETRIES,
+      Type.INT,
+      YahooConfigConstants.DEFAULT_RETRIES,
+      Importance.MEDIUM,
+      YahooConfigConstants.NBR_OF_RETRIES_DOC)
+
+
+    .define(YahooConfigConstants.POLL_INTERVAL,
+      Type.LONG,
+      YahooConfigConstants.DEFAULT_POLL_INTERVAL,
+      Importance.HIGH,
+      YahooConfigConstants.POLL_INTERVAL_DOC)
+
+  /*.define(YahooConfigConstants.ERROR_RETRY_INTERVAL,
+    Type.INT,
+    YahooConfigConstants.ERROR_RETRY_INTERVAL_DEFAULT,
+    Importance.MEDIUM,
+    YahooConfigConstants.ERROR_RETRY_INTERVAL_DOC)
+*/
+}

--- a/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/DataRetrieverManager.scala
+++ b/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/DataRetrieverManager.scala
@@ -1,0 +1,136 @@
+package com.datamountaineer.streamreactor.connect.yahoo.source
+
+import java.util
+import java.util.concurrent.{CountDownLatch, Executors, LinkedBlockingQueue, TimeUnit}
+
+import com.datamountaineer.streamreactor.connect.concurrent.ExecutorExtension._
+import com.datamountaineer.streamreactor.connect.yahoo.source.StockHelper._
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import org.apache.kafka.connect.source.SourceRecord
+import yahoofinance.Stock
+import yahoofinance.quotes.fx.FxQuote
+
+import scala.util.Try
+
+case class DataRetrieverManager(dataRetriever: FinanceDataRetriever,
+                                fx: Array[String],
+                                fxKafkaTopic: Option[String],
+                                stocks: Array[String],
+                                stocksKafkaTopic: Option[String],
+                                queryInterval: Long) extends AutoCloseable with StrictLogging {
+  require(fx.nonEmpty || stocks.nonEmpty, "Need to provide at least one quote or stock")
+
+  private val workers = {
+    (if (fx.nonEmpty) 1 else 0) + (if (stocks.nonEmpty) 1 else 0)
+  }
+  private val queue = new LinkedBlockingQueue[SourceRecord]()
+  private val latch = new CountDownLatch(workers)
+  private val latchStart = new CountDownLatch(workers)
+  @volatile private var poll = true
+  private val threadPool = Executors.newFixedThreadPool(workers)
+
+  def getRecords(): java.util.List[SourceRecord] = {
+    val recs = new util.LinkedList[SourceRecord]()
+    if (queue.drainTo(recs) > 0) recs
+    else null
+  }
+
+  def start() = {
+    if (fx.nonEmpty) {
+      startQuotesWorker()
+    } else {
+      logger.warn("No FX quotes requested. The Yahoo connector won't poll for quotes data.")
+    }
+
+    if (stocks.nonEmpty) {
+      startStocksWorker()
+    } else {
+      logger.warn("No STOCKS requested. The Yahoo connector won't poll for stocks data.")
+    }
+    latchStart.await()
+  }
+
+  override def close(): Unit = {
+    poll = false
+    latch.await()
+    threadPool.shutdownNow()
+    Try(threadPool.awaitTermination(5000, TimeUnit.MILLISECONDS))
+  }
+
+  private def addFx(fx: Seq[FxQuote]) = {
+    fx.foreach { q =>
+      val record = q.toSourceRecord(fxKafkaTopic.get)
+      queue.add(record)
+    }
+  }
+
+  private def addStocks(stocks: Seq[Stock]) = {
+    stocks.foreach { s =>
+      val sourceRecord = s.toSourceRecord(stocksKafkaTopic.get)
+      queue.add(sourceRecord)
+    }
+  }
+
+  private def startQuotesWorker(): Unit = {
+    threadPool.submit {
+      latchStart.countDown()
+      while (poll) {
+        try {
+          val data = dataRetriever.getFx(fx)
+          addFx(data)
+        } catch {
+          case t: Throwable =>
+            logger.error("An error occured trying to get the Yahoo data." + t.getMessage, t)
+        }
+
+        Thread.sleep(queryInterval)
+      }
+
+      latch.countDown()
+    }
+  }
+
+  private def startStocksWorker(): Unit = {
+    threadPool.submit {
+      latchStart.countDown()
+      while (poll) {
+        try {
+          val data = dataRetriever.getStocks(stocks)
+          addStocks(data)
+        } catch {
+          case t: Throwable =>
+            logger.error("An error occured trying to get the Yahoo data." + t.getMessage, t)
+        }
+
+        Thread.sleep(queryInterval)
+      }
+
+      latch.countDown()
+    }
+  }
+}
+
+/*
+object YahooFinanceWrapper{
+  /**
+    * Retrieves the given stocks including historical values
+    *
+    * @param stocks
+    * @param includeHistorical
+    * @return
+    */
+  def apply(stocks: Array[String], includeHistorical: Boolean = false) = {
+    YahooFinance.get(stocks, includeHistorical).values()
+  }
+
+  /**
+    *
+    * @param stocks
+    * @param from
+    * @return
+    */
+  def apply(stocks: Array[String], from: Calendar) = {
+    YahooFinance.get(stocks, from).values()
+  }
+}
+*/

--- a/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/FinanceApi.scala
+++ b/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/FinanceApi.scala
@@ -1,0 +1,18 @@
+package com.datamountaineer.streamreactor.connect.yahoo.source
+
+import yahoofinance.quotes.fx.FxQuote
+import yahoofinance.{Stock, YahooFinance}
+
+import scala.collection.JavaConversions._
+
+trait FinanceDataRetriever {
+  def getFx(symbols: Array[String]): Seq[FxQuote]
+
+  def getStocks(stocks: Array[String]): Seq[Stock]
+}
+
+case object YahooDataRetriever extends FinanceDataRetriever {
+  override def getFx(fx: Array[String]): Seq[FxQuote] = YahooFinance.getFx(fx).values().toSeq
+
+  override def getStocks(symbols: Array[String]): Seq[Stock] = YahooFinance.get(symbols).values.toSeq
+}

--- a/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/StockHelper.scala
+++ b/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/StockHelper.scala
@@ -1,0 +1,171 @@
+package com.datamountaineer.streamreactor.connect.yahoo.source
+
+import java.util
+import java.util.Collections
+
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
+import org.apache.kafka.connect.source.SourceRecord
+import yahoofinance.Stock
+import yahoofinance.quotes.fx.FxQuote
+
+import scala.collection.JavaConversions._
+
+object StockHelper {
+
+  implicit class FxQuoteToSourceRecordConverter(val fx: FxQuote) extends AnyVal {
+    def toSourceRecord(topic: String) = {
+      new SourceRecord(Collections.singletonMap("Yahoo", fx.getSymbol),
+        null,
+        topic,
+        getFxSchema,
+        getFxStruct)
+    }
+
+    def getFxStruct() = {
+      new Struct(getFxSchema())
+        .put("symbol", fx.getSymbol)
+        .put("price", fx.getPrice(false).doubleValue())
+    }
+  }
+
+  implicit class StockToSourceRecordConverter(val stock: Stock) extends AnyVal {
+    def toSourceRecord(topic: String, includeHistory: Boolean = false) = {
+      val record = new SourceRecord(Collections.singletonMap("Yahoo", stock.getSymbol),
+        null,
+        topic,
+        getStockSchema(),
+        getStruct(includeHistory)
+      )
+      record
+    }
+
+    private def getStruct(includeHistory: Boolean) = {
+      val struct = new Struct(getStockSchema())
+        .put("currency", stock.getCurrency)
+        .put("name", stock.getName)
+        .put("symbol", stock.getSymbol)
+        .put("stock_exchange", stock.getStockExchange)
+
+      val structWithDividend = Option(stock.getDividend(false)).foldLeft(struct) { (s, d) =>
+        if (d.getAnnualYield != null) s.put("annual_yield", d.getAnnualYield.doubleValue())
+        if (d.getAnnualYieldPercent != null) s.put("annual_yield_percentage", d.getAnnualYieldPercent.doubleValue())
+        if (d.getExDate != null) s.put("ex_date", d.getExDate.getTimeInMillis)
+        if (d.getPayDate != null) s.put("pay_date", d.getPayDate.getTimeInMillis)
+        s
+      }
+
+      val structWithQuote = Option(stock.getQuote(false)).foldLeft(structWithDividend) { (s, q) =>
+        s.put("ask", q.getAsk.doubleValue())
+          .put("ask_size", q.getAskSize)
+          .put("ask_avg_volumne", q.getAvgVolume)
+          .put("bid", q.getBid.doubleValue())
+          .put("bid_size", q.getBidSize)
+          .put("change", q.getChange.doubleValue())
+          .put("change_percentage", q.getChangeInPercent.doubleValue())
+          .put("change_from_avg50", q.getChangeFromAvg50.doubleValue())
+          .put("change_from_avg50_percentage", q.getChangeFromAvg50InPercent.doubleValue())
+          .put("change_from_year_high", q.getChangeFromYearHigh.doubleValue())
+          .put("change_from_year_high_percentage", q.getChangeFromYearHighInPercent.doubleValue())
+          .put("change_from_year_low", q.getChangeFromYearLow.doubleValue())
+          .put("change_from_year_low_percentage", q.getChangeFromYearLowInPercent.doubleValue())
+          .put("day_high", q.getDayHigh.doubleValue())
+          .put("day_low", q.getDayLow.doubleValue())
+          .put("last_trade_size", q.getLastTradeSize)
+          .put("last_trade_time", q.getLastTradeTime.getTimeInMillis)
+          .put("open", q.getOpen.doubleValue())
+          .put("previous_close", q.getPreviousClose.doubleValue())
+          .put("price", q.getPrice.doubleValue())
+          .put("price_avg50", q.getPriceAvg50.doubleValue())
+          .put("price_avg200", q.getPriceAvg200.doubleValue())
+          .put("volume", q.getVolume)
+          .put("year_high", q.getYearHigh.doubleValue())
+          .put("year_low", q.getYearLow.doubleValue())
+      }
+
+      if (includeHistory) {
+        val historicalValues = stock.getHistory()
+        if (historicalValues != null && historicalValues.size() > 0) {
+
+          val linkedList = new util.LinkedList[Struct]
+          val quotes = historicalValues.foreach { q =>
+            val structHistory = new Struct(getStockHistoricalSchema())
+              .put("adj_close", q.getAdjClose.doubleValue())
+              .put("close", q.getAdjClose.doubleValue())
+              .put("date", q.getDate.getTimeInMillis)
+              .put("high", q.getHigh.doubleValue())
+              .put("low", q.getLow.doubleValue())
+              .put("open", q.getOpen.doubleValue())
+              .put("volume", q.getVolume)
+
+            linkedList.add(structHistory)
+          }
+
+          structWithDividend.put("history", linkedList)
+        }
+      }
+      else structWithDividend
+    }
+  }
+
+  def getStockHistoricalSchema() = {
+    val builderHistory = SchemaBuilder.struct
+    builderHistory
+      .field("adj_close", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("close", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("date", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("high", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("low", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("open", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("volume", Schema.OPTIONAL_INT64_SCHEMA)
+    builderHistory.build()
+  }
+
+  def getStockSchema() = {
+
+    val builder = SchemaBuilder.struct
+    builder.field("currency", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("stock_exchange", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("symbol", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("annual_yield", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("annual_yield_percentage", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("ex_date", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("pay_date", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ask", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("ask_size", Schema.OPTIONAL_INT32_SCHEMA)
+      .field("ask_avg_volumne", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("bid", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("bid_size", Schema.OPTIONAL_INT32_SCHEMA)
+      .field("change", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("change_percentage", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("change_from_avg50", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("change_from_avg50_percentage", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("change_from_year_high", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("change_from_year_high_percentage", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("change_from_year_low", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("change_from_year_low_percentage", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("day_high", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("day_low", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("last_trade_size", Schema.OPTIONAL_INT32_SCHEMA)
+      .field("last_trade_time", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("open", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("previous_close", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("price", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("price_avg50", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("price_avg200", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("volume", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("year_high", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("year_low", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("history", SchemaBuilder.array(getStockHistoricalSchema()).build())
+    builder.build()
+  }
+
+  def getFxSchema() = {
+    SchemaBuilder.struct()
+      .field("symbol", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("price", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .build()
+  }
+}
+
+

--- a/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/YahooSourceConnector.scala
+++ b/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/YahooSourceConnector.scala
@@ -1,0 +1,74 @@
+/**
+  * Copyright 2016 Datamountaineer.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
+
+package com.datamountaineer.streamreactor.connect.yahoo.source
+
+import java.util
+
+import com.datamountaineer.streamreactor.connect.yahoo.config.DistributeConfigurationFn
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import org.apache.kafka.connect.connector.Task
+import org.apache.kafka.connect.source.SourceConnector
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+/**
+  * <h1>YahooSourceConnector</h1>
+  * Kafka connect Yahoo Source connector
+  *
+  * Sets up YahooSourceTask and configurations for the tasks.
+  */
+class YahooSourceConnector extends SourceConnector with StrictLogging {
+
+  private var configProps: Option[util.Map[String, String]] = None
+
+  /**
+    * Defines the sink class to use
+    *
+    * @return
+    */
+  override def taskClass(): Class[_ <: Task] = classOf[YahooSourceTask]
+
+  /**
+    * Set the configuration for each work and determine the split.
+    *
+    * @param maxTasks The max number of task workers be can spawn.
+    * @return a List of configuration properties per worker.
+    **/
+  override def taskConfigs(maxTasks: Int): util.List[util.Map[String, String]] = {
+    DistributeConfigurationFn(maxTasks, configProps.get.asScala.toMap).map(_.asJava).asJava
+  }
+
+  /**
+    * Start the sink and set to configuration.
+    *
+    * @param props A map of properties for the connector and worker.
+    **/
+  override def start(props: util.Map[String, String]): Unit = {
+    logger.info(s"Starting Cassandra source task with ${props.toString}.")
+    configProps = Some(props)
+  }
+
+  override def stop(): Unit = {}
+
+  /**
+    * Gets the version of this sink.
+    *
+    * @return
+    */
+  override def version(): String = getClass.getPackage.getImplementationVersion
+}

--- a/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/YahooSourceTask.scala
+++ b/kafka-connect-yahoo/src/main/scala/com/datamountaineer/streamreactor/connect/yahoo/source/YahooSourceTask.scala
@@ -1,0 +1,90 @@
+/**
+  * Copyright 2016 Datamountaineer.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
+
+package com.datamountaineer.streamreactor.connect.yahoo.source
+
+import java.util
+
+import com.datamountaineer.streamreactor.connect.yahoo.config.{YahooSettings, YahooSourceConfig}
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import io.confluent.common.config.{AbstractConfig, ConfigException}
+import org.apache.kafka.connect.source.{SourceRecord, SourceTask}
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+
+class YahooSourceTask extends SourceTask with StrictLogging with YahooSourceConfig {
+  private var taskConfig: Option[AbstractConfig] = None
+  private var dataManager: Option[DataRetrieverManager] = None
+
+  /**
+    * Starts the Yahoo source, parsing the options and setting up the reader.
+    *
+    * @param props A map of supplied properties.
+    **/
+  override def start(props: util.Map[String, String]): Unit = {
+
+    logger.info(
+      s"""
+         |Configuration for task
+         |${props.asScala}
+      """.stripMargin)
+    //get configuration for this task
+    taskConfig = Try(new AbstractConfig(configDef, props)) match {
+      case Failure(f) => throw new ConfigException("Couldn't start YahooSource due to configuration error.", f)
+      case Success(s) => Some(s)
+    }
+
+    val settings = YahooSettings(taskConfig.get)
+
+    dataManager = Some(DataRetrieverManager(
+      YahooDataRetriever,
+      settings.fxQuotes.toArray,
+      settings.fxKafkaTopic,
+      settings.stocks.toArray,
+      settings.stocksKafkaTopic,
+      settings.pollInterval))
+
+    dataManager.foreach(_.start())
+  }
+
+  /**
+    * Called by the Framework
+    *
+    * Checks the Yahoo data retriever for records of SourceRecords.
+    *
+    * @return A util.List of SourceRecords.
+    **/
+  override def poll(): util.List[SourceRecord] = dataManager.map(_.getRecords()).orNull
+
+  /**
+    * Stop the task and close readers.
+    *
+    **/
+  override def stop(): Unit = {
+    logger.info("Stopping Yahoo source...")
+    dataManager.foreach(_.close())
+    logger.info("Yahoo data retriever stopped.")
+  }
+
+  /**
+    * Gets the version of this sink.
+    *
+    * @return
+    */
+  override def version(): String = getClass.getPackage.getImplementationVersion
+
+}

--- a/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/config/DistributeConfigurationFnTest.scala
+++ b/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/config/DistributeConfigurationFnTest.scala
@@ -1,0 +1,423 @@
+package com.datamountaineer.streamreactor.connect.yahoo.config
+
+import org.scalatest.{Matchers, WordSpec}
+
+class DistributeConfigurationFnTest extends WordSpec with Matchers {
+  val key1 = "key"
+  val value1 = "value"
+  "DistributeConfigurationFn" should {
+
+    "1 stock by 3 partitions" in {
+
+      val map = Map(YahooConfigConstants.STOCKS -> "s1",
+        key1 -> value1)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 1
+
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1.length shouldBe 1
+      s1 shouldBe Array("s1")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+    }
+
+    "1 fx by 3 partitions" in {
+      val map = Map(YahooConfigConstants.FX -> "s1",
+        key1 -> value1)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 1
+
+      val s1 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s1.length shouldBe 1
+      s1 shouldBe Array("s1")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+    }
+
+    "3 stock by 3 partitions" in {
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3",
+        key1 -> value1)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1.length shouldBe 1
+      s1 shouldBe Array("s1")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+
+      val s2 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s2.length shouldBe 1
+      s2 shouldBe Array("s2")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+
+      val s3 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3.length shouldBe 1
+      s3 shouldBe Array("s3")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+    }
+
+    "3 fx by 3 partitions" in {
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3",
+        key1 -> value1)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1.length shouldBe 1
+      s1 shouldBe Array("s1")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+
+      val s2 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s2.length shouldBe 1
+      s2 shouldBe Array("s2")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+
+      val s3 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3.length shouldBe 1
+      s3 shouldBe Array("s3")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+    }
+
+    "5 stocks by 3 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3,s4,s5",
+        key -> value)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1.length shouldBe 2
+      s1 shouldBe Array("s1", "s2")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+
+      result(1).size shouldBe 2
+      val s2 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s2.length shouldBe 2
+      s2 shouldBe Array("s3", "s4")
+      result(1).get(key1).get shouldBe value1
+
+      result(2).size shouldBe 2
+      val s3 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3.length shouldBe 1
+      s3 shouldBe Array("s5")
+      result(2).get(key1).get shouldBe value1
+    }
+
+    "5 stocks and 3 fx by 3 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3,s4,s5",
+        YahooConfigConstants.FX -> "s1,s2,s3",
+        key -> value)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      result.head.size shouldBe 3
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1 shouldBe Array("s1", "s2")
+
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 3
+
+      val s2 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s2 shouldBe Array("s1")
+
+      result(1).size shouldBe 3
+      val s3 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3 shouldBe Array("s3", "s4")
+      result(1).get(key1).get shouldBe value1
+
+      val s4 = result(1).get(YahooConfigConstants.FX).get.split(',')
+      s4 shouldBe Array("s2")
+
+      result(2).size shouldBe 3
+      val s5 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s5 shouldBe Array("s5")
+      result(2).get(key1).get shouldBe value1
+      val s6 = result(2).get(YahooConfigConstants.FX).get.split(',')
+      s6 shouldBe Array("s3")
+    }
+
+    "5 stocks and 4 fx by 3 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3,s4,s5",
+        YahooConfigConstants.FX -> "s1,s2,s3,s4",
+        key -> value)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      result.head.size shouldBe 3
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1 shouldBe Array("s1", "s2")
+
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 3
+
+      val s2 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s2 shouldBe Array("s1", "s2")
+
+      result(1).size shouldBe 3
+      val s3 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3 shouldBe Array("s3", "s4")
+      result(1).get(key1).get shouldBe value1
+
+      val s4 = result(1).get(YahooConfigConstants.FX).get.split(',')
+      s4 shouldBe Array("s3", "s4")
+
+      result(2).size shouldBe 2
+      val s5 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s5 shouldBe Array("s5")
+      result(2).get(key1).get shouldBe value1
+    }
+
+    "5 stocks and 1 fx by 3 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3,s4,s5",
+        YahooConfigConstants.FX -> "s1",
+        key -> value)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      result.head.size shouldBe 3
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1 shouldBe Array("s1", "s2")
+
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 3
+
+      val s2 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s2 shouldBe Array("s1")
+
+      result(1).size shouldBe 2
+      val s3 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3 shouldBe Array("s3", "s4")
+      result(1).get(key1).get shouldBe value1
+
+      result(2).size shouldBe 2
+      val s5 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s5 shouldBe Array("s5")
+      result(2).get(key1).get shouldBe value1
+    }
+
+    "5 stocks and 2 fx by 3 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3,s4,s5",
+        YahooConfigConstants.FX -> "s1,s2",
+        key -> value)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      result.head.size shouldBe 3
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1 shouldBe Array("s1", "s2")
+
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 3
+
+      val s2 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s2 shouldBe Array("s1")
+
+      result(1).size shouldBe 3
+      val s3 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3 shouldBe Array("s3", "s4")
+      result(1).get(key1).get shouldBe value1
+      result(1).get(YahooConfigConstants.FX).get.split(',') shouldBe Array("s2")
+
+      result(2).size shouldBe 2
+      val s5 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s5 shouldBe Array("s5")
+      result(2).get(key1).get shouldBe value1
+    }
+
+    "5 stocks and 5 fx by 3 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3,s4,s5",
+        YahooConfigConstants.FX -> "s1,s2,s3,s4,s5",
+        key -> value)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      result.head.size shouldBe 3
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1 shouldBe Array("s1", "s2")
+
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 3
+
+      val s2 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s2 shouldBe Array("s1", "s2")
+
+      result(1).size shouldBe 3
+      val s3 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3 shouldBe Array("s3", "s4")
+      result(1).get(key1).get shouldBe value1
+
+      val s4 = result(1).get(YahooConfigConstants.FX).get.split(',')
+      s4 shouldBe Array("s3", "s4")
+
+      result(2).size shouldBe 3
+      val s5 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s5 shouldBe Array("s5")
+      result(2).get(key1).get shouldBe value1
+      result(2).get(YahooConfigConstants.FX).get.split(',') shouldBe Array("s5")
+    }
+
+
+    "5 stocks and 6 fx by 3 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3,s4,s5",
+        YahooConfigConstants.FX -> "s1,s2,s3,s4,s5,s6",
+        key -> value)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      result.head.size shouldBe 3
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1 shouldBe Array("s1", "s2")
+
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 3
+
+      val s2 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s2 shouldBe Array("s1", "s2")
+
+      result(1).size shouldBe 3
+      val s3 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3 shouldBe Array("s3", "s4")
+      result(1).get(key1).get shouldBe value1
+
+      val s4 = result(1).get(YahooConfigConstants.FX).get.split(',')
+      s4 shouldBe Array("s3", "s4")
+
+      result(2).size shouldBe 3
+      val s5 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s5 shouldBe Array("s5")
+      result(2).get(key1).get shouldBe value1
+      result(2).get(YahooConfigConstants.FX).get.split(',') shouldBe Array("s5", "s6")
+    }
+
+
+    "5 stocks and 7 fx by 3 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3,s4,s5",
+        YahooConfigConstants.FX -> "s1,s2,s3,s4,s5,s6,s7",
+        key -> value)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      result.head.size shouldBe 3
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1 shouldBe Array("s1", "s2")
+
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 3
+
+      val s2 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s2 shouldBe Array("s1", "s2", "s3")
+
+      result(1).size shouldBe 3
+      val s3 = result(1).get(YahooConfigConstants.STOCKS).get.split(',')
+      s3 shouldBe Array("s3", "s4")
+      result(1).get(key1).get shouldBe value1
+
+      val s4 = result(1).get(YahooConfigConstants.FX).get.split(',')
+      s4 shouldBe Array("s4", "s5", "s6")
+
+      result(2).size shouldBe 3
+      val s5 = result(2).get(YahooConfigConstants.STOCKS).get.split(',')
+      s5 shouldBe Array("s5")
+      result(2).get(key1).get shouldBe value1
+      result(2).get(YahooConfigConstants.FX).get.split(',') shouldBe Array("s7")
+    }
+
+    "4 stocks and 8 fx by 4 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.STOCKS -> "s1,s2,s3,s4",
+        YahooConfigConstants.FX -> "s1,s2,s3,s4,s5,s6,s7,s8",
+        key -> value)
+
+      val result = DistributeConfigurationFn(4, map)
+      result.size shouldBe 4
+
+      result.head.size shouldBe 3
+      val s1 = result.head.get(YahooConfigConstants.STOCKS).get.split(',')
+      s1 shouldBe Array("s1")
+
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 3
+
+      val s2 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s2 shouldBe Array("s1", "s2")
+
+      result(1).size shouldBe 3
+      result(1).get(YahooConfigConstants.STOCKS).get.split(',') shouldBe Array("s2")
+      result(1).get(key1).get shouldBe value1
+      result(1).get(YahooConfigConstants.FX).get.split(',') shouldBe Array("s3", "s4")
+
+      result(2).size shouldBe 3
+      result(2).get(YahooConfigConstants.STOCKS).get.split(',') shouldBe Array("s3")
+      result(2).get(key1).get shouldBe value1
+      result(2).get(YahooConfigConstants.FX).get.split(',') shouldBe Array("s5", "s6")
+
+      result(3).size shouldBe 3
+      result(3).get(YahooConfigConstants.STOCKS).get.split(',') shouldBe Array("s4")
+      result(3).get(key1).get shouldBe value1
+      result(3).get(YahooConfigConstants.FX).get.split(',') shouldBe Array("s7", "s8")
+    }
+
+    "5 fx with 3 partitions" in {
+      val key = "key"
+      val value = "value"
+      val map = Map(YahooConfigConstants.FX -> "s1,s2,s3,s4,s5",
+        key -> value)
+
+      val result = DistributeConfigurationFn(3, map)
+      result.size shouldBe 3
+
+      val s1 = result.head.get(YahooConfigConstants.FX).get.split(',')
+      s1.length shouldBe 2
+      s1 shouldBe Array("s1", "s2")
+      result.head.get(key1).get shouldBe value1
+      result.head.size shouldBe 2
+
+      result(1).size shouldBe 2
+      val s2 = result(1).get(YahooConfigConstants.FX).get.split(',')
+      s2.length shouldBe 2
+      s2 shouldBe Array("s3", "s4")
+      result(1).get(key1).get shouldBe value1
+
+      result(2).size shouldBe 2
+      val s3 = result(2).get(YahooConfigConstants.FX).get.split(',')
+      s3.length shouldBe 1
+      s3 shouldBe Array("s5")
+      result(2).get(key1).get shouldBe value1
+    }
+  }
+}

--- a/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/config/YahooSettingsTest.scala
+++ b/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/config/YahooSettingsTest.scala
@@ -1,0 +1,97 @@
+package com.datamountaineer.streamreactor.connect.yahoo.config
+
+import com.datamountaineer.streamreactor.connect.errors.{ErrorPolicyEnum, ThrowErrorPolicy}
+import io.confluent.common.config.{AbstractConfig, ConfigException}
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.JavaConversions._
+
+class YahooSettingsTest extends WordSpec with Matchers with YahooSourceConfig {
+  "YahooSettings" should {
+    "throw an exception if the fx symbols are set but not the kafka topic for fx" in {
+      intercept[ConfigException] {
+        val props = Map(
+          YahooConfigConstants.FX -> "USDGBP=",
+          YahooConfigConstants.STOCKS -> "MSFT",
+          YahooConfigConstants.STOCKS_KAFKA_TOPIC -> "stocks_topic",
+          YahooConfigConstants.ERROR_POLICY -> "THROW",
+          YahooConfigConstants.NBR_OF_RETRIES -> "1"
+        )
+
+        val config = new AbstractConfig(configDef, props)
+        YahooSettings(config)
+      }
+    }
+
+    "throw an exception if the fx symbols are not set but the kafka topic for fx is" in {
+      intercept[ConfigException] {
+        val props = Map(
+          YahooConfigConstants.FX_KAFKA_TOPIC -> "fx_topic",
+          YahooConfigConstants.STOCKS -> "MSFT",
+          YahooConfigConstants.STOCKS_KAFKA_TOPIC -> "stocks_topic",
+          YahooConfigConstants.ERROR_POLICY -> "THROW",
+          YahooConfigConstants.NBR_OF_RETRIES -> "1"
+        )
+
+        val config = new AbstractConfig(configDef, props)
+        YahooSettings(config)
+      }
+    }
+
+    "throw an exception if the stocks/quotes symbols are set but not the kafka topic for stocks/quotes" in {
+      intercept[ConfigException] {
+        val props = Map(
+          YahooConfigConstants.FX -> "USDGBP=",
+          YahooConfigConstants.FX_KAFKA_TOPIC -> "topic",
+          YahooConfigConstants.STOCKS -> "MSFT",
+          YahooConfigConstants.ERROR_POLICY -> "THROW",
+          YahooConfigConstants.NBR_OF_RETRIES -> "1"
+        )
+
+        val config = new AbstractConfig(configDef, props)
+        YahooSettings(config)
+      }
+    }
+    "throw an exception if the stocks/quotes symbols are not set but the kafka topic for stocks/quotes is" in {
+      intercept[ConfigException] {
+        val props = Map(
+          YahooConfigConstants.FX -> "USDGBP=",
+          YahooConfigConstants.FX_KAFKA_TOPIC -> "topic",
+          YahooConfigConstants.STOCKS -> "MSFT",
+          YahooConfigConstants.ERROR_POLICY -> "THROW",
+          YahooConfigConstants.NBR_OF_RETRIES -> "1"
+        )
+
+        val config = new AbstractConfig(configDef, props)
+        YahooSettings(config)
+      }
+    }
+
+    "create the settings instance" in {
+      val props = Map(
+        YahooConfigConstants.FX -> "USDGBP=,USDGBP=,EURGBP=",
+        YahooConfigConstants.FX_KAFKA_TOPIC -> "topic_fx",
+        YahooConfigConstants.STOCKS -> "MSFT,GOOGL ,MSFT ",
+        YahooConfigConstants.STOCKS_KAFKA_TOPIC -> "topic_stocks",
+        YahooConfigConstants.ERROR_POLICY -> "THROW",
+        YahooConfigConstants.NBR_OF_RETRIES -> "1",
+        YahooConfigConstants.POLL_INTERVAL -> "1500"
+      )
+
+      val config = new AbstractConfig(configDef, props)
+      val settings = YahooSettings(config)
+      settings.pollInterval shouldBe 1500
+      settings.errorPolicy.getClass shouldBe classOf[ThrowErrorPolicy]
+
+      settings.fxQuotes.size shouldBe 2
+      settings.fxQuotes.contains("USDGBP=") shouldBe true
+      settings.fxQuotes.contains("EURGBP=") shouldBe true
+      settings.fxKafkaTopic shouldBe Some("topic_fx")
+
+      settings.stocks.size shouldBe 2
+      settings.stocks.contains("MSFT") shouldBe true
+      settings.stocks.contains("GOOGL") shouldBe true
+      settings.stocksKafkaTopic shouldBe Some("topic_stocks")
+    }
+  }
+}

--- a/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/source/DataRetrieverManagerTest.scala
+++ b/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/source/DataRetrieverManagerTest.scala
@@ -1,0 +1,194 @@
+package com.datamountaineer.streamreactor.connect.yahoo.source
+
+import java.math.BigDecimal
+import java.util.Calendar
+
+import org.apache.kafka.connect.data.Struct
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import yahoofinance.Stock
+import yahoofinance.quotes.fx.FxQuote
+import yahoofinance.quotes.stock.{StockDividend, StockQuote}
+
+class DataRetrieverManagerTest extends WordSpec with Matchers with MockitoSugar {
+  "DataRetriever" should {
+    "throw an exception if no fx and stocks have been provided" in {
+      intercept[IllegalArgumentException] {
+        DataRetrieverManager(mock[FinanceDataRetriever],
+          Array.empty[String],
+          Some("Some"),
+          Array.empty[String],
+          Some("topic1"),
+          1500)
+      }
+    }
+
+    "poll quotes once before we stop the retriever" in {
+      val dataRetriever = mock[FinanceDataRetriever]
+
+      val quotes = Array("GBPEUR")
+      val dataManager = DataRetrieverManager(dataRetriever,
+        quotes,
+        Some("topicFX"),
+        Array.empty[String],
+        Some("topic1"),
+        500)
+
+      val gbpEurQuote1 = new FxQuote("GBPEUR=", new BigDecimal("1.18"))
+      when(dataRetriever.getFx(quotes)).thenReturn(Seq(gbpEurQuote1))
+      dataManager.start()
+      Thread.sleep(250)
+      dataManager.close()
+
+      val records = dataManager.getRecords()
+      (records != null) shouldBe true
+      records.size() shouldBe 1
+      val record = records.get(0)
+      record.topic() shouldBe "topicFX"
+      record.valueSchema() shouldBe StockHelper.getFxSchema()
+      val struct = record.value().asInstanceOf[Struct]
+      struct.get("symbol") shouldBe gbpEurQuote1.getSymbol
+      struct.get("price") shouldBe gbpEurQuote1.getPrice().doubleValue()
+    }
+
+    "poll quotes twice before we stop the retriever" in {
+      val dataRetriever = mock[FinanceDataRetriever]
+
+      val quotes = Array("GBPEUR")
+      val dataManager = DataRetrieverManager(dataRetriever,
+        quotes,
+        Some("topicFX"),
+        Array.empty[String],
+        Some("topic1"),
+        500)
+
+      val gbpEurQuote1 = new FxQuote("GBPEUR=", new BigDecimal("1.18"))
+      val gbpEurQuote2 = new FxQuote("GBPUSD=", new BigDecimal("1.32"))
+
+      when(dataRetriever.getFx(quotes)).thenReturn(Seq(gbpEurQuote1), Seq(gbpEurQuote2))
+      dataManager.start()
+      Thread.sleep(750)
+      dataManager.close()
+
+      val records = dataManager.getRecords()
+      (records != null) shouldBe true
+      records.size() shouldBe 2
+      var record = records.get(0)
+      record.topic() shouldBe "topicFX"
+      record.valueSchema() shouldBe StockHelper.getFxSchema()
+      var struct = record.value().asInstanceOf[Struct]
+      struct.get("symbol") shouldBe gbpEurQuote1.getSymbol
+      struct.get("price") shouldBe gbpEurQuote1.getPrice().doubleValue()
+
+      record = records.get(1)
+      record.topic() shouldBe "topicFX"
+      record.valueSchema() shouldBe StockHelper.getFxSchema()
+      struct = record.value().asInstanceOf[Struct]
+      struct.get("symbol") shouldBe gbpEurQuote2.getSymbol
+      struct.get("price") shouldBe gbpEurQuote2.getPrice().doubleValue()
+      dataManager.getRecords() shouldBe null
+    }
+  }
+
+  "poll stocks once before we stop the retriever" in {
+    val dataRetriever = mock[FinanceDataRetriever]
+
+    val stocks = Array("MSFT")
+    val dataManager = DataRetrieverManager(dataRetriever,
+      Array.empty[String],
+      None,
+      stocks,
+      Some("topicStocks"),
+      500)
+
+    val msft = getMSFTStock()
+
+    when(dataRetriever.getStocks(stocks)).thenReturn(Seq(msft))
+    dataManager.start()
+    Thread.sleep(250)
+    dataManager.close()
+
+    val records = dataManager.getRecords()
+    (records != null) shouldBe true
+    records.size() shouldBe 1
+    val record = records.get(0)
+    record.topic() shouldBe "topicStocks"
+    record.valueSchema() shouldBe StockHelper.getStockSchema()
+    val struct = record.value().asInstanceOf[Struct]
+    struct.get("symbol") shouldBe msft.getSymbol
+    struct.get("ask") shouldBe msft.getQuote(false).getAsk.doubleValue()
+    struct.get("bid") shouldBe msft.getQuote(false).getBid.doubleValue()
+  }
+
+  "poll stocks twice before we stop the retriever" in {
+    val dataRetriever = mock[FinanceDataRetriever]
+
+    val stocks = Array("MSFT")
+    val dataManager = DataRetrieverManager(dataRetriever,
+      Array.empty[String],
+      None,
+      stocks,
+      Some("topicStocks"),
+      500)
+
+    val msft = getMSFTStock()
+    val msft2 = getMSFTStock()
+    msft2.getQuote(false).setAsk(new BigDecimal("1.811"))
+    msft2.getQuote(false).setBid(new BigDecimal("1.411"))
+
+    when(dataRetriever.getStocks(stocks)).thenReturn(Seq(msft), Seq(msft2))
+    dataManager.start()
+    Thread.sleep(750)
+    dataManager.close()
+
+    val records = dataManager.getRecords()
+    (records != null) shouldBe true
+    records.size() shouldBe 2
+    val record = records.get(0)
+    record.topic() shouldBe "topicStocks"
+    record.valueSchema() shouldBe StockHelper.getStockSchema()
+    val struct = record.value().asInstanceOf[Struct]
+    struct.get("symbol") shouldBe msft.getSymbol
+    struct.get("ask") shouldBe msft.getQuote(false).getAsk.doubleValue()
+    struct.get("bid") shouldBe msft.getQuote(false).getBid.doubleValue()
+
+    val record1 = records.get(1)
+    record1.topic() shouldBe "topicStocks"
+    record1.valueSchema() shouldBe StockHelper.getStockSchema()
+    val struct1 = record1.value().asInstanceOf[Struct]
+    struct1.get("symbol") shouldBe msft.getSymbol
+    struct1.get("ask") shouldBe msft2.getQuote(false).getAsk.doubleValue()
+    struct1.get("bid") shouldBe msft2.getQuote(false).getBid.doubleValue()
+  }
+
+  private def getMSFTStock() = {
+    val stock = new Stock("MSFT")
+    val calendar = Calendar.getInstance()
+    val dividend = new StockDividend("MSF", calendar, calendar, new java.math.BigDecimal("100.191"), new BigDecimal("7.1"))
+    stock.setDividend(dividend)
+    stock.setCurrency("GBP")
+    stock.setName("Microsoft")
+    stock.setStockExchange("LDN")
+    val quote = new StockQuote("MSFT")
+    quote.setAsk(new BigDecimal("52.29"))
+    quote.setAskSize(1000)
+    quote.setAvgVolume(189)
+    quote.setBid(new BigDecimal("52.21"))
+    quote.setBidSize(1259)
+    quote.setDayHigh(new BigDecimal("52.36"))
+    quote.setDayLow(new BigDecimal("51.01"))
+    quote.setLastTradeSize(100)
+    quote.setLastTradeTime(calendar)
+    quote.setOpen(new BigDecimal("51.73"))
+    quote.setPreviousClose(new BigDecimal("51.38"))
+    quote.setPrice(new BigDecimal("52.30"))
+    quote.setPriceAvg50(new BigDecimal("52.11"))
+    quote.setPriceAvg200(new BigDecimal("52.01"))
+    quote.setVolume(3000000)
+    quote.setYearHigh(new BigDecimal("56.85"))
+    quote.setYearLow(new BigDecimal("39.85"))
+    stock.setQuote(quote)
+    stock
+  }
+}

--- a/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/source/SourceRecordConverterTest.scala
+++ b/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/source/SourceRecordConverterTest.scala
@@ -1,0 +1,57 @@
+package com.datamountaineer.streamreactor.connect.yahoo.source
+
+import com.datamountaineer.streamreactor.connect.yahoo.source.StockHelper._
+import org.scalatest.WordSpec
+import yahoofinance.YahooFinance
+
+import scala.collection.JavaConversions._
+
+//Only available for local testing as it goes to yahoo to read the data
+class SourceRecordConverterTest extends WordSpec {
+  "Converter" should {
+    "convert FXQuotes to SourceRecord" ignore {
+      val currencies = Array(
+        "EURAUD=X",
+        "EURCHF=X",
+        "EURCAD=X",
+        "EURNZD=X",
+        "GBPAUD=X",
+        "GBPCAD=X",
+        "GBPCHF=X",
+        "GBPNZD=X",
+        "CADCHF=X",
+        "EURCZK=X",
+        "EURPLN=X",
+        "EURTRY=X",
+        "EURHUF=X",
+        "USDMXN=X",
+        "USDHUF=X",
+        "USDZAR=X",
+        "USDTRY=X",
+        "USDPLN=X",
+        "USDCZK=X",
+        "USDRUB=X"
+      )
+      YahooFinance.getFx(currencies).values().foreach(_.toSourceRecord("topicFx"))
+    }
+
+    "convert stocks to SourceRecord" ignore {
+      val stocks = Array(
+        "WMT",
+        "YHOO",
+        "MSFT",
+        "^GSPC",
+        "Vfinx",
+        "KKR",
+        "BP",
+        "C",
+        "AAPL",
+        "BRK-B",
+        "SPY"
+      )
+
+      YahooFinance.get(stocks, true).values().foreach(_.toSourceRecord("topicStocks", true))
+    }
+  }
+
+}

--- a/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/source/StockHelperTest.scala
+++ b/kafka-connect-yahoo/src/test/scala/com.datamountaineer.streamreactor.connect.yahoo/source/StockHelperTest.scala
@@ -1,0 +1,264 @@
+package com.datamountaineer.streamreactor.connect.yahoo.source
+
+import java.math.BigDecimal
+import java.util.{Calendar, Collections}
+
+import com.datamountaineer.streamreactor.connect.yahoo.source.StockHelper._
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
+import org.scalatest.{Matchers, WordSpec}
+import yahoofinance.Stock
+import yahoofinance.quotes.fx.FxQuote
+import yahoofinance.quotes.stock.{StockDividend, StockQuote}
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+class StockHelperTest extends WordSpec with Matchers {
+
+  "convert a quote to a struct" in {
+    val quote = new FxQuote("GBPEUR=", new BigDecimal("0.89"))
+    val record = quote.toSourceRecord("topic_fx")
+    record.topic() shouldBe "topic_fx"
+    record.sourcePartition() shouldBe Collections.singletonMap("Yahoo", "GBPEUR=")
+    record.sourceOffset() shouldBe null
+    record.key() shouldBe null
+    record.keySchema() shouldBe null
+
+    val schema = record.valueSchema()
+    schema.`type`() shouldBe Schema.Type.STRUCT
+    val fields = schema.fields().map { f => f.name() -> f.schema() }.toMap.asJava
+    fields.size shouldBe 2
+    fields.get("symbol") shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    fields.get("price") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    val struct = record.value().asInstanceOf[Struct]
+    struct.getString("symbol") shouldBe "GBPEUR="
+    struct.getFloat64("price") shouldBe 0.89
+  }
+
+  "convert a stock to a struct" in {
+    val stock = new Stock("MSFT")
+    val calendar = Calendar.getInstance()
+    val dividend = new StockDividend("MSF", calendar, calendar, new java.math.BigDecimal("100.191"), new BigDecimal("7.1"))
+    stock.setDividend(dividend)
+    stock.setCurrency("GBP")
+    stock.setName("Microsoft")
+    stock.setStockExchange("LDN")
+    val quote = new StockQuote("MSFT")
+    quote.setAsk(new BigDecimal("52.29"))
+    quote.setAskSize(1000)
+    quote.setAvgVolume(189)
+    quote.setBid(new BigDecimal("52.21"))
+    quote.setBidSize(1259)
+    quote.setDayHigh(new BigDecimal("52.36"))
+    quote.setDayLow(new BigDecimal("51.01"))
+    quote.setLastTradeSize(100)
+    quote.setLastTradeTime(calendar)
+    quote.setOpen(new BigDecimal("51.73"))
+    quote.setPreviousClose(new BigDecimal("51.38"))
+    quote.setPrice(new BigDecimal("52.30"))
+    quote.setPriceAvg50(new BigDecimal("52.11"))
+    quote.setPriceAvg200(new BigDecimal("52.01"))
+    quote.setVolume(3000000)
+    quote.setYearHigh(new BigDecimal("56.85"))
+    quote.setYearLow(new BigDecimal("39.85"))
+    stock.setQuote(quote)
+
+    val record = stock.toSourceRecord("topic_stocks", false)
+    record.topic() shouldBe "topic_stocks"
+    record.sourcePartition() shouldBe Collections.singletonMap("Yahoo", "MSFT")
+
+    record.sourceOffset() shouldBe null
+
+    record.key() shouldBe null
+    record.keySchema() shouldBe null
+
+    val schema = record.valueSchema()
+    schema.`type`() shouldBe Schema.Type.STRUCT
+    val fields = schema.fields().map { f => f.name() -> f.schema() }.toMap.asJava
+    fields.get("currency") shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    fields.get("name") shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    fields.get("stock_exchange") shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    fields.get("symbol") shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    fields.get("annual_yield") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("annual_yield_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("ex_date") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("pay_date") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("ask") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("ask_size") shouldBe Schema.OPTIONAL_INT32_SCHEMA
+    fields.get("ask_avg_volumne") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("bid") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("bid_size") shouldBe Schema.OPTIONAL_INT32_SCHEMA
+    fields.get("change") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_avg50") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_avg50_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_year_high") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_year_high_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_year_low") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_year_low_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("day_high") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("day_low") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("last_trade_size") shouldBe Schema.OPTIONAL_INT32_SCHEMA
+    fields.get("last_trade_time") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("open") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("previous_close") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("price") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("price_avg50") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("price_avg200") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("volume") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("year_high") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("year_low") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("history") shouldBe SchemaBuilder.array(StockHelper.getStockHistoricalSchema()).build()
+
+    val struct = record.value().asInstanceOf[Struct]
+    val history = struct.getArray("history")
+    history shouldBe null
+
+    struct.getString("currency") shouldBe "GBP"
+    struct.getString("name") shouldBe "Microsoft"
+    struct.getString("stock_exchange") shouldBe "LDN"
+    struct.getString("symbol") shouldBe "MSFT"
+    struct.getFloat64("annual_yield") shouldBe 100.191
+    struct.getFloat64("annual_yield_percentage") shouldBe 7.1
+    struct.getInt64("ex_date") shouldBe calendar.getTimeInMillis
+    struct.getInt64("pay_date") shouldBe calendar.getTimeInMillis
+    struct.getFloat64("ask") shouldBe 52.29
+    struct.getInt32("ask_size") shouldBe 1000
+    struct.getInt64("ask_avg_volumne") shouldBe 189
+    struct.getFloat64("bid") shouldBe 52.21
+    struct.getInt32("bid_size") shouldBe 1259
+    struct.getFloat64("change") shouldBe 0.92
+    struct.getFloat64("change_percentage") shouldBe 1.79
+    struct.getFloat64("change_from_avg50") shouldBe 0.19
+    struct.getFloat64("change_from_avg50_percentage") shouldBe 0.36
+    struct.getFloat64("change_from_year_high") shouldBe -4.55
+    struct.getFloat64("change_from_year_high_percentage") shouldBe -8.0
+    struct.getFloat64("change_from_year_low") shouldBe 12.45
+    struct.getFloat64("change_from_year_low_percentage") shouldBe 31.24
+    struct.getFloat64("day_high") shouldBe 52.36
+    struct.getFloat64("day_low") shouldBe 51.01
+    struct.getInt32("last_trade_size") shouldBe 100
+    struct.getInt64("last_trade_time") shouldBe calendar.getTimeInMillis
+    struct.getFloat64("open") shouldBe 51.73
+    struct.getFloat64("previous_close") shouldBe 51.38
+    struct.getFloat64("price") shouldBe 52.30
+    struct.getFloat64("price_avg50") shouldBe 52.11
+    struct.getFloat64("price_avg200") shouldBe 52.01
+    struct.getInt64("volume") shouldBe 3000000
+    struct.getFloat64("year_high") shouldBe 56.85
+    struct.getFloat64("year_low") shouldBe 39.85
+  }
+
+  "convert a stock to a struct without dividend" in {
+    val stock = new Stock("MSFT")
+    val calendar = Calendar.getInstance()
+    stock.setCurrency("GBP")
+    stock.setName("Microsoft")
+    stock.setStockExchange("LDN")
+    val quote = new StockQuote("MSFT")
+    quote.setAsk(new BigDecimal("52.29"))
+    quote.setAskSize(1000)
+    quote.setAvgVolume(189)
+    quote.setBid(new BigDecimal("52.21"))
+    quote.setBidSize(1259)
+    quote.setDayHigh(new BigDecimal("52.36"))
+    quote.setDayLow(new BigDecimal("51.01"))
+    quote.setLastTradeSize(100)
+    quote.setLastTradeTime(calendar)
+    quote.setOpen(new BigDecimal("51.73"))
+    quote.setPreviousClose(new BigDecimal("51.38"))
+    quote.setPrice(new BigDecimal("52.30"))
+    quote.setPriceAvg50(new BigDecimal("52.11"))
+    quote.setPriceAvg200(new BigDecimal("52.01"))
+    quote.setVolume(3000000)
+    quote.setYearHigh(new BigDecimal("56.85"))
+    quote.setYearLow(new BigDecimal("39.85"))
+    stock.setQuote(quote)
+
+    val record = stock.toSourceRecord("topic_stocks", false)
+    record.topic() shouldBe "topic_stocks"
+    record.sourcePartition() shouldBe Collections.singletonMap("Yahoo", "MSFT")
+
+    record.sourceOffset() shouldBe null
+
+    record.key() shouldBe null
+    record.keySchema() shouldBe null
+
+    val schema = record.valueSchema()
+    schema.`type`() shouldBe Schema.Type.STRUCT
+    val fields = schema.fields().map { f => f.name() -> f.schema() }.toMap.asJava
+    fields.get("currency") shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    fields.get("name") shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    fields.get("stock_exchange") shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    fields.get("symbol") shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    fields.get("annual_yield") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("annual_yield_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("ex_date") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("pay_date") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("ask") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("ask_size") shouldBe Schema.OPTIONAL_INT32_SCHEMA
+    fields.get("ask_avg_volumne") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("bid") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("bid_size") shouldBe Schema.OPTIONAL_INT32_SCHEMA
+    fields.get("change") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_avg50") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_avg50_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_year_high") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_year_high_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_year_low") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("change_from_year_low_percentage") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("day_high") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("day_low") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("last_trade_size") shouldBe Schema.OPTIONAL_INT32_SCHEMA
+    fields.get("last_trade_time") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("open") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("previous_close") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("price") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("price_avg50") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("price_avg200") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("volume") shouldBe Schema.OPTIONAL_INT64_SCHEMA
+    fields.get("year_high") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("year_low") shouldBe Schema.OPTIONAL_FLOAT64_SCHEMA
+    fields.get("history") shouldBe SchemaBuilder.array(StockHelper.getStockHistoricalSchema()).build()
+
+    val struct = record.value().asInstanceOf[Struct]
+    val history = struct.getArray("history")
+    history shouldBe null
+
+    struct.getString("currency") shouldBe "GBP"
+    struct.getString("name") shouldBe "Microsoft"
+    struct.getString("stock_exchange") shouldBe "LDN"
+    struct.getString("symbol") shouldBe "MSFT"
+    struct.getFloat64("annual_yield") shouldBe null
+    struct.getFloat64("annual_yield_percentage") shouldBe null
+    struct.getInt64("ex_date") shouldBe null
+    struct.getInt64("pay_date") shouldBe null
+    struct.getFloat64("ask") shouldBe 52.29
+    struct.getInt32("ask_size") shouldBe 1000
+    struct.getInt64("ask_avg_volumne") shouldBe 189
+    struct.getFloat64("bid") shouldBe 52.21
+    struct.getInt32("bid_size") shouldBe 1259
+    struct.getFloat64("change") shouldBe 0.92
+    struct.getFloat64("change_percentage") shouldBe 1.79
+    struct.getFloat64("change_from_avg50") shouldBe 0.19
+    struct.getFloat64("change_from_avg50_percentage") shouldBe 0.36
+    struct.getFloat64("change_from_year_high") shouldBe -4.55
+    struct.getFloat64("change_from_year_high_percentage") shouldBe -8.0
+    struct.getFloat64("change_from_year_low") shouldBe 12.45
+    struct.getFloat64("change_from_year_low_percentage") shouldBe 31.24
+    struct.getFloat64("day_high") shouldBe 52.36
+    struct.getFloat64("day_low") shouldBe 51.01
+    struct.getInt32("last_trade_size") shouldBe 100
+    struct.getInt64("last_trade_time") shouldBe calendar.getTimeInMillis
+    struct.getFloat64("open") shouldBe 51.73
+    struct.getFloat64("previous_close") shouldBe 51.38
+    struct.getFloat64("price") shouldBe 52.30
+    struct.getFloat64("price_avg50") shouldBe 52.11
+    struct.getFloat64("price_avg200") shouldBe 52.01
+    struct.getInt64("volume") shouldBe 3000000
+    struct.getFloat64("year_high") shouldBe 56.85
+    struct.getFloat64("year_low") shouldBe 39.85
+  }
+
+}

--- a/kafka-socket-streamer/src/main/scala/com/datamountaineer/streamreactor/socketstreamer/Main.scala
+++ b/kafka-socket-streamer/src/main/scala/com/datamountaineer/streamreactor/socketstreamer/Main.scala
@@ -18,11 +18,12 @@ package com.datamountaineer.streamreactor.socketstreamer
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.RouteResult.route2HandlerFlow
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import com.datamountaineer.streamreactor.socketstreamer.routes.SocketRoutes
+
 import scala.concurrent.duration.DurationInt
-import akka.http.scaladsl.server.RouteResult.route2HandlerFlow
 
 object Main extends App with SocketRoutes {
   implicit val system = ActorSystem()

--- a/kafka-socket-streamer/src/main/scala/com/datamountaineer/streamreactor/socketstreamer/flows/KafkaFlow.scala
+++ b/kafka-socket-streamer/src/main/scala/com/datamountaineer/streamreactor/socketstreamer/flows/KafkaFlow.scala
@@ -16,13 +16,11 @@
 
 package com.datamountaineer.streamreactor.socketstreamer.flows
 
-import java.io.Serializable
 import java.util.{Calendar, Properties}
 
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.ws.TextMessage.Strict
-import spray.json._
 import akka.http.scaladsl.model.ws.{Message, TextMessage}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Flow, Sink, Source}
@@ -30,16 +28,16 @@ import com.datamountaineer.streamreactor.socketstreamer.ConfigurationLoader
 import com.datamountaineer.streamreactor.socketstreamer.domain._
 import com.softwaremill.react.kafka.{ConsumerProperties, ReactiveKafka}
 import com.typesafe.scalalogging.slf4j.StrictLogging
+import de.heikoseeberger.akkasse.ServerSentEvent
 import io.confluent.kafka.serializers.KafkaAvroDecoder
 import kafka.utils.VerifiableProperties
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.reactivestreams.Publisher
+import spray.json._
 
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
-import de.heikoseeberger.akkasse.ServerSentEvent
-
 import scala.language.postfixOps
 
 trait KafkaFlow extends KafkaConstants with ConfigurationLoader with StrictLogging with Protocols {

--- a/kafka-socket-streamer/src/test/scala/com/datamountaineer/streamreactor/socketstreamer/RouteTest.scala
+++ b/kafka-socket-streamer/src/test/scala/com/datamountaineer/streamreactor/socketstreamer/RouteTest.scala
@@ -1,15 +1,8 @@
 package com.datamountaineer.streamreactor.socketstreamer
 
-import akka.http.scaladsl.server.{Directives, StandardRoute}
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
 import com.datamountaineer.streamreactor.socketstreamer.routes.SocketRoutes
 import org.scalatest._
-import akka.http.scaladsl.testkit.{RouteTestTimeout, WSProbe}
-import akka.stream.ActorMaterializer
-import akka.http.scaladsl.server.Directives._
-import com.datamountaineer.streamreactor.socketstreamer.domain.KafkaRequestProps
-import de.heikoseeberger.akkasse.EventStreamMarshalling
-import scala.concurrent.duration._
 
 /**
   * Created by andrew@datamountaineer.com on 16/03/16. 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,9 @@ include 'kafka-socket-streamer',
         //'kafka-connect-druid',
         'kafka-connect-kudu',
         'kafka-connect-cassandra',
+        'kafka-connect-yahoo',
         'kafka-connect-hbase',
         'kafka-connect-redis',
         'kafka-connect-rethink',
         'kafka-connect-jms'
+


### PR DESCRIPTION
* first cut for Yahoo Connect Source
minor coding fixes for hbase/cassandra

* small improvement allowing for unit tests

* adding unit tests

* cleanup and check for assigned topics, upgrade to kcql 0.4 for topic names with -

* cleanup and check for assigned topics, upgrade to kcql 0.4 for topic names with -

* cleanup and check for assigned topics, upgrade to kcql 0.4 for topic names with -

* code improvement - avoid converting the SinkRecords util.Collection to Set

* distributing the config across the workers

* [kafka-connect-druid] now compiles

For some reasons, all the import statements not targeting java.*
namespace had disappeared.

* avoid doing to Seq on the util.collection as it creates a stream so it will submit the tasks to the pool in  the awaitfailfast (thus throwing an exception)

moved the json conversion in the thread.