### PR TITLE
Fix guava classloader conflict

### DIFF
--- a/kafka-connect-cassandra/build.gradle
+++ b/kafka-connect-cassandra/build.gradle
@@ -19,7 +19,11 @@ project(":kafka-connect-cassandra") {
     }
 
     dependencies {
-        compile "com.datastax.cassandra:cassandra-driver-core:$cassandraDriverVersion"
+        compile ("com.datastax.cassandra:cassandra-driver-core:$cassandraDriverVersion") {
+            exclude group: 'com.google.guava', module: 'guava'
+        }
+        compile group: 'com.google.guava', name: 'guava', version: '19.0'
+
         testCompile "com.google.code.findbugs:jsr305:1.3.9"
         testCompile ("org.apache.cassandra:cassandra-all:$cassandraVersion") {
             exclude group:"org.slf4j", module: "log4j-over-slf4j"

--- a/kafka-connect-druid/build.gradle
+++ b/kafka-connect-druid/build.gradle
@@ -12,7 +12,9 @@ project(":kafka-connect-druid") {
         compile "com.github.nscala-time:nscala-time_$scalaMajorVersion:2.12.0"
         compile ("io.druid:tranquility-core_$scalaMajorVersion:$tranquilityCoreVersion") {
             exclude group : "com.sun.jersey"
+            exclude group: 'com.google.guava', module: 'guava'
         }
+        compile group: 'com.google.guava', name: 'guava', version: '19.0'
         testCompile("org.kitesdk:kite-minicluster:$kiteMiniClusterVersion")
     }
 }

--- a/kafka-connect-hbase/build.gradle
+++ b/kafka-connect-hbase/build.gradle
@@ -8,7 +8,10 @@ project(":kafka-connect-hbase") {
     dependencies {
         compile("org.apache.hbase:hbase-client:$hbaseClientVersion") {
             exclude group : "com.sun.jersey"
+            exclude group: 'com.google.guava', module: 'guava'
         }
+        compile group: 'com.google.guava', name: 'guava', version: '19.0'
+
         testCompile("org.kitesdk:kite-minicluster:$kiteMiniClusterVersion")
         testCompile("org.apache.hbase:hbase-server:$hbaseServerVersion")
         testCompile("org.json4s:json4s-native_$scalaMajorVersion:$json4sVersion")

--- a/kafka-connect-kudu/build.gradle
+++ b/kafka-connect-kudu/build.gradle
@@ -5,7 +5,9 @@ project(":kafka-connect-kudu") {
 
     dependencies {
         compile "org.kududb:kudu-client:$kuduVersion"
-        testCompile "com.datamountaineer:kafka-testkit:$dataMountaineerTestKitVersion"
+        testCompile("com.datamountaineer:kafka-testkit:$dataMountaineerTestKitVersion") {
+            exclude group: 'com.google.guava', module: 'guava'
+        }
+        testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
     }
-
 }


### PR DESCRIPTION
Fx classloader conflict wrt guava versions 12.0.1 and 16.0.1 that conflict with a guava function used in elastic sink plugin

REF: https://github.com/datamountaineer/stream-reactor/issues/71

Within the set of connectors provided, the following guava versions are in use through transient dependencies: 12.0.1, 16.0.1, 18.0 and 19.0. The elastic sink connector depends on a guava function that was not yet available in 12.0.1 and 16.0.1... so hence the up-step of those transient dependencies.