### PR TITLE
Fix typo in mongo sink settings: kqcl -> kcql.

### DIFF
--- a/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoConfig.scala
+++ b/kafka-connect-mongodb/src/main/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoConfig.scala
@@ -49,7 +49,7 @@ object MongoConfig {
   val NBR_OF_RETRIES_DOC = "The maximum number of times to try the write again."
   val NBR_OF_RETIRES_DEFAULT = 20
 
-  val KCQL_CONFIG = "connect.mongo.sink.kqcl"
+  val KCQL_CONFIG = "connect.mongo.sink.kcql"
   val KCQL_DOC = "KCQL expression describing field selection and data routing to the target mongo db."
 
 

--- a/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSinkSettingsTest.scala
+++ b/kafka-connect-mongodb/src/test/scala/com/datamountaineer/streamreactor/connect/mongodb/config/MongoSinkSettingsTest.scala
@@ -83,7 +83,7 @@ class MongoSinkSettingsTest extends WordSpec with Matchers {
       settings.ignoredField shouldBe Map("topic1" -> Set.empty)
     }
 
-    "throw an exception if the kqcl is not valid" in {
+    "throw an exception if the kcql is not valid" in {
       val map = Map(
         MongoConfig.DATABASE_CONFIG -> "database1",
         MongoConfig.CONNECTION_CONFIG -> "mongodb://localhost:27017",


### PR DESCRIPTION
Signed-off-by: Marios Andreopoulos <opensource@andmarios.com>