### PR TITLE
Select column fix

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -19,9 +19,9 @@ package com.datamountaineer.streamreactor.connect.cassandra.source
 import java.text.SimpleDateFormat
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.{ Collections, Date }
+import java.util.{Collections, Date}
 
-import com.datamountaineer.streamreactor.connect.cassandra.config.{ CassandraConfigConstants, CassandraSourceSetting }
+import com.datamountaineer.streamreactor.connect.cassandra.config.{CassandraConfigConstants, CassandraSourceSetting}
 import com.datamountaineer.streamreactor.connect.cassandra.utils.CassandraResultSetWrapper.resultSetFutureToScala
 import com.datamountaineer.streamreactor.connect.cassandra.utils.CassandraUtils
 import com.datamountaineer.streamreactor.connect.offsets.OffsetHandler
@@ -29,12 +29,12 @@ import com.datastax.driver.core._
 import com.datastax.driver.core.utils.UUIDs
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.errors.ConnectException
-import org.apache.kafka.connect.source.{ SourceRecord, SourceTaskContext }
+import org.apache.kafka.connect.source.{SourceRecord, SourceTaskContext}
 
 import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 import java.util.Arrays.ArrayList
 import java.util.ArrayList
 import org.apache.kafka.common.config.ConfigException
@@ -44,9 +44,9 @@ import org.apache.kafka.common.config.ConfigException
  * stream-reactor
  */
 class CassandraTableReader(private val session: Session,
-    private val setting: CassandraSourceSetting,
-    private val context: SourceTaskContext,
-    var queue: LinkedBlockingQueue[SourceRecord]) extends StrictLogging {
+                           private val setting: CassandraSourceSetting,
+                           private val context: SourceTaskContext,
+                           var queue: LinkedBlockingQueue[SourceRecord]) extends StrictLogging {
 
   logger.info(s"Received setting:\n ${setting.toString}")
   private val defaultTimestamp = "1900-01-01 00:00:00.0000000Z"
@@ -127,12 +127,14 @@ class CassandraTableReader(private val session: Session,
         //checking we are querying here,don't issue another query for the table if we querying,
         // maintain incremental order
         logger.debug(s"Still querying for $keySpace.$table. Current queue size in ${queue.size()}.")
-      } //wait for next poll interval to expire
+      } 
+      //wait for next poll interval to expire
       else if (lastPoll + setting.pollInterval < newPollTime) {
         lastPoll = newPollTime
         query()
       }
-    } else {
+    } 
+    else {
       logger.info(s"Told to stop for $keySpace.$table.")
     }
   }
@@ -150,7 +152,8 @@ class CassandraTableReader(private val session: Session,
     //execute the query, gives us back a future resultset
     val frs = if (setting.bulkImportMode) {
       resultSetFutureToScala(fireQuery())
-    } else {
+    } 
+    else {
       resultSetFutureToScala(bindAndFireQuery(lowerBound, upperBound))
     }
 
@@ -317,9 +320,9 @@ class CassandraTableReader(private val session: Session,
 
 object CassandraTableReader {
   def apply(session: Session,
-    setting: CassandraSourceSetting,
-    context: SourceTaskContext,
-    queue: LinkedBlockingQueue[SourceRecord]): CassandraTableReader = {
+            setting: CassandraSourceSetting,
+            context: SourceTaskContext,
+            queue: LinkedBlockingQueue[SourceRecord]): CassandraTableReader = {
     //return a reader
     new CassandraTableReader(session = session,
       setting = setting,

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -19,9 +19,9 @@ package com.datamountaineer.streamreactor.connect.cassandra.source
 import java.text.SimpleDateFormat
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.{Collections, Date}
+import java.util.{ Collections, Date }
 
-import com.datamountaineer.streamreactor.connect.cassandra.config.{CassandraConfigConstants, CassandraSourceSetting}
+import com.datamountaineer.streamreactor.connect.cassandra.config.{ CassandraConfigConstants, CassandraSourceSetting }
 import com.datamountaineer.streamreactor.connect.cassandra.utils.CassandraResultSetWrapper.resultSetFutureToScala
 import com.datamountaineer.streamreactor.connect.cassandra.utils.CassandraUtils
 import com.datamountaineer.streamreactor.connect.offsets.OffsetHandler
@@ -29,21 +29,24 @@ import com.datastax.driver.core._
 import com.datastax.driver.core.utils.UUIDs
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.errors.ConnectException
-import org.apache.kafka.connect.source.{SourceRecord, SourceTaskContext}
+import org.apache.kafka.connect.source.{ SourceRecord, SourceTaskContext }
 
 import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
+import java.util.Arrays.ArrayList
+import java.util.ArrayList
+import org.apache.kafka.common.config.ConfigException
 
 /**
-  * Created by andrew@datamountaineer.com on 20/04/16.
-  * stream-reactor
-  */
+ * Created by andrew@datamountaineer.com on 20/04/16.
+ * stream-reactor
+ */
 class CassandraTableReader(private val session: Session,
-                           private val setting: CassandraSourceSetting,
-                           private val context: SourceTaskContext,
-                           var queue: LinkedBlockingQueue[SourceRecord]) extends StrictLogging {
+    private val setting: CassandraSourceSetting,
+    private val context: SourceTaskContext,
+    var queue: LinkedBlockingQueue[SourceRecord]) extends StrictLogging {
 
   logger.info(s"Received setting:\n ${setting.toString}")
   private val defaultTimestamp = "1900-01-01 00:00:00.0000000Z"
@@ -63,11 +66,11 @@ class CassandraTableReader(private val session: Session,
   private val schemaName = s"$keySpace.$table".replace('-', '.')
 
   /**
-    * Build a map of table to offset.
-    *
-    * @param context SourceTaskContext for this task.
-    * @return The last stored offset.
-    **/
+   * Build a map of table to offset.
+   *
+   * @param context SourceTaskContext for this task.
+   * @return The last stored offset.
+   */
   private def buildOffsetMap(context: SourceTaskContext): Option[Date] = {
     val offsetStorageKey = CassandraConfigConstants.ASSIGNED_TABLES
     val tables = List(topic)
@@ -77,13 +80,15 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Build a preparedStatement for the given table.
-    *
-    * @return A map of table -> prepared statements..
-    **/
+   * Build a preparedStatement for the given table.
+   *
+   * @return A map of table -> prepared statements..
+   */
   private def getPreparedStatements: PreparedStatement = {
+    val faList = setting.routes.getFieldAlias.map(next => next.getField).toList
     //if no columns set then select the whole table
-    val f = if (fields == null || fields.isEmpty) "*" else fields.mkString(",")
+    val f = if (faList == null || faList.isEmpty) "*" else faList.mkString(",")
+    logger.info(s"the fields to select are $f")
 
     val selectStatement = if (setting.bulkImportMode) {
       s"SELECT $f FROM $keySpace.$table"
@@ -92,15 +97,22 @@ class CassandraTableReader(private val session: Session,
         s"FROM $keySpace.$table " +
         s"WHERE $timestampCol > maxTimeuuid(?) AND $timestampCol <= minTimeuuid(?) " + " ALLOW FILTERING"
     }
+
+    if (!setting.bulkImportMode && !f.contains(timestampCol)) {
+      val msg = s"the timestamp column ($timestampCol) must appear in the SELECT statement"
+      logger.error(msg)
+      throw new ConfigException(msg)
+    }
+
     val statement = session.prepare(selectStatement)
     setting.consistencyLevel.foreach(statement.setConsistencyLevel)
     statement
   }
 
   /**
-    * Fires cassandra queries for the rows in a loop incrementing the timestamp
-    * with each loop. Row returned are put into the queue.
-    **/
+   * Fires cassandra queries for the rows in a loop incrementing the timestamp
+   * with each loop. Row returned are put into the queue.
+   */
   def read(): Unit = {
     if (!stop.get()) {
 
@@ -115,14 +127,12 @@ class CassandraTableReader(private val session: Session,
         //checking we are querying here,don't issue another query for the table if we querying,
         // maintain incremental order
         logger.debug(s"Still querying for $keySpace.$table. Current queue size in ${queue.size()}.")
-      }
-      //wait for next poll interval to expire
+      } //wait for next poll interval to expire
       else if (lastPoll + setting.pollInterval < newPollTime) {
         lastPoll = newPollTime
         query()
       }
-    }
-    else {
+    } else {
       logger.info(s"Told to stop for $keySpace.$table.")
     }
   }
@@ -149,12 +159,12 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Bind and execute the preparedStatement and set querying to true.
-    *
-    * @param previous The previous timestamp to bind.
-    * @param now      The current timestamp on the db to bind.
-    * @return a ResultSet.
-    **/
+   * Bind and execute the preparedStatement and set querying to true.
+   *
+   * @param previous The previous timestamp to bind.
+   * @param now      The current timestamp on the db to bind.
+   * @return a ResultSet.
+   */
   private def bindAndFireQuery(previous: Date, now: Date) = {
     //bind the offset and db time
     val formattedPrevious = dateFormatter.format(previous)
@@ -165,10 +175,10 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Execute the preparedStatement and set querying to true.
-    *
-    * @return a ResultSet.
-    **/
+   * Execute the preparedStatement and set querying to true.
+   *
+   * @return a ResultSet.
+   */
   private def fireQuery(): ResultSetFuture = {
     //bind the offset and db time
     val bound = preparedStatement.bind()
@@ -178,11 +188,11 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Iterate over the resultset, extract SinkRecords
-    * and add to the queue.
-    *
-    * @param f Cassandra Future ResultSet to iterate over.
-    **/
+   * Iterate over the resultset, extract SinkRecords
+   * and add to the queue.
+   *
+   * @param f Cassandra Future ResultSet to iterate over.
+   */
   private def process(f: Future[ResultSet]) = {
     //get the max offset per query
     var maxOffset: Option[Date] = None
@@ -224,11 +234,11 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Process a Cassandra row, convert it to a SourceRecord and put in queue
-    *
-    * @param row The Cassandra row to process.
-    *
-    **/
+   * Process a Cassandra row, convert it to a SourceRecord and put in queue
+   *
+   * @param row The Cassandra row to process.
+   *
+   */
   private def processRow(row: Row) = {
     //convert the cassandra row to a struct
     val struct = CassandraUtils.convert(row, schemaName)
@@ -252,20 +262,20 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Extract the CQL UUID timestamp and return a date
-    *
-    * @param row The row to extract the UUI from
-    * @return A java.util.Date
-    **/
+   * Extract the CQL UUID timestamp and return a date
+   *
+   * @param row The row to extract the UUI from
+   * @return A java.util.Date
+   */
   private def extractTimestamp(row: Row): Date = {
     new Date(UUIDs.unixTimestamp(row.getUUID(setting.timestampColumn.get)))
   }
 
   /**
-    * Set the offset for the table and set querying to false
-    *
-    * @param offset the date to set the offset to
-    **/
+   * Set the offset for the table and set querying to false
+   *
+   * @param offset the date to set the offset to
+   */
   private def reset(offset: Option[Date]) = {
     //set the offset to the 'now' bind value
     val table = setting.routes.getTarget
@@ -277,8 +287,8 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Closed down the driver session and cluster.
-    **/
+   * Closed down the driver session and cluster.
+   */
   def close(): Unit = {
     logger.info("Shutting down Queries.")
     stopQuerying()
@@ -286,8 +296,8 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Tell me to stop processing.
-    **/
+   * Tell me to stop processing.
+   */
   def stopQuerying(): Unit = {
     val table = setting.routes.getTarget
     stop.set(true)
@@ -298,8 +308,8 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Is the reader in the middle of a query
-    **/
+   * Is the reader in the middle of a query
+   */
   def isQuerying: Boolean = {
     querying.get()
   }
@@ -307,9 +317,9 @@ class CassandraTableReader(private val session: Session,
 
 object CassandraTableReader {
   def apply(session: Session,
-            setting: CassandraSourceSetting,
-            context: SourceTaskContext,
-            queue: LinkedBlockingQueue[SourceRecord]): CassandraTableReader = {
+    setting: CassandraSourceSetting,
+    context: SourceTaskContext,
+    queue: LinkedBlockingQueue[SourceRecord]): CassandraTableReader = {
     //return a reader
     new CassandraTableReader(session = session,
       setting = setting,

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskSpecifyColumns.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskSpecifyColumns.scala
@@ -1,0 +1,138 @@
+/*
+ *  Copyright 2017 Datamountaineer.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.datamountaineer.streamreactor.connect.cassandra.source
+
+import java.util.concurrent.LinkedBlockingQueue
+
+import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
+import com.datamountaineer.streamreactor.connect.cassandra.config.{ CassandraConfigSource, CassandraSettings }
+import com.datamountaineer.streamreactor.connect.queues.QueueHelpers
+import com.datamountaineer.streamreactor.connect.schemas.ConverterUtil
+import com.fasterxml.jackson.databind.JsonNode
+import org.apache.kafka.connect.source.SourceRecord
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ BeforeAndAfter, Matchers, WordSpec }
+
+import scala.collection.JavaConverters._
+import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigConstants
+import org.apache.kafka.common.config.ConfigException
+
+/**
+ * test incremental mode specifying a subset of table columns
+ * note: the timestamp column is required as part of SELECT
+ */
+class TestCassandraSourceTaskSpecifyColumns extends WordSpec with Matchers with BeforeAndAfter with MockitoSugar with TestConfig
+    with ConverterUtil {
+
+  before {
+    startEmbeddedCassandra()
+  }
+
+  after {
+    stopEmbeddedCassandra()
+  }
+
+  "A Cassandra SourceTask should read records with only columns specified" in {
+    val session = createTableAndKeySpace(secure = true, ssl = false)
+
+    val sql = s"INSERT INTO $CASSANDRA_KEYSPACE.$TABLE2" +
+      "(id, int_field, long_field, string_field, timestamp_field) " +
+      "VALUES ('id1', 2, 3, 'magic_string', now());"
+    session.execute(sql)
+
+    //wait for cassandra write a little
+    Thread.sleep(1000)
+
+    val taskContext = getSourceTaskContextDefault
+    //get config
+    val config = {
+      Map(
+        CassandraConfigConstants.CONTACT_POINTS -> CONTACT_POINT,
+        CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
+        CassandraConfigConstants.USERNAME -> USERNAME,
+        CassandraConfigConstants.PASSWD -> PASSWD,
+        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE2 PK timestamp_field",
+        CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE2",
+        CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
+        CassandraConfigConstants.POLL_INTERVAL -> "1000").asJava
+    }
+
+    //get task
+    val task = new CassandraSourceTask()
+    //initialise the tasks context
+    task.initialize(taskContext)
+    //start task
+    task.start(config)
+
+    //trigger poll to have the readers execute a query and add to the queue
+    task.poll()
+
+    //wait a little for the poll to catch the records
+    while (task.queueSize(TABLE2) == 0) {
+      Thread.sleep(5000)
+    }
+
+    //call poll again to drain the queue
+    val records = task.poll()
+
+    val sourceRecord = records.asScala.head
+    //check a field
+    val json: JsonNode = convertValueToJson(sourceRecord)
+    println(json)
+    json.get("string_field").asText().equals("magic_string") shouldBe true
+    json.get("int_field") shouldBe null
+    //stop task
+    task.stop()
+  }
+
+  "A Cassandra SourceTask should throw exception when timestamp column is not specified" in {
+    val session = createTableAndKeySpace(secure = true, ssl = false)
+
+    val sql = s"INSERT INTO $CASSANDRA_KEYSPACE.$TABLE2" +
+      "(id, int_field, long_field, string_field, timestamp_field) " +
+      "VALUES ('id1', 2, 3, 'magic_string', now());"
+    session.execute(sql)
+
+    //wait for cassandra write a little
+    Thread.sleep(1000)
+
+    val taskContext = getSourceTaskContextDefault
+    //get config
+    val config = {
+      Map(
+        CassandraConfigConstants.CONTACT_POINTS -> CONTACT_POINT,
+        CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
+        CassandraConfigConstants.USERNAME -> USERNAME,
+        CassandraConfigConstants.PASSWD -> PASSWD,
+        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT string_field FROM $TABLE2 PK timestamp_field",
+        CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE2",
+        CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
+        CassandraConfigConstants.POLL_INTERVAL -> "1000").asJava
+    }
+
+    val task = new CassandraSourceTask()
+    task.initialize(taskContext)
+    try {
+      task.start(config)
+      fail()
+    } catch {
+      case _: ConfigException => // Expected, so continue
+    }
+  }
+}
+
+


### PR DESCRIPTION
Was working w/ Kafka Connect pushing data from Cassandra to a Topic
I was setting the` connect.cassandra.source.kcql` to the following `INSERT INTO idocs-topic SELECT json_doc FROM idocs_events PK idoc_event_ts` but all of the columns in the table were included in the data written to the Topic

Here is a possible fix that honors the columns in the SELECT 