### PR TITLE
Refactor to prepare for withunwrap KCQL capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ target/
 /kafka-connect-coap/Californium.properties
 Californium.properties
 /gradle/wrapper/gradle-wrapper.properties
+/.DS_Store

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtils.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtils.scala
@@ -63,13 +63,21 @@ object CassandraUtils {
     * @param row The Cassandra resultset row to convert
     * @return a SourceRecord
     * */
-  def convert(row: Row, name: String) : Struct = {
+  def convert(row: Row, name: String, ignoreList: List[String]) : Struct = {
     //TODO do we need to get the list of columns everytime?
 
     val cols = row.getColumnDefinitions
-    val connectSchema = convertToConnectSchema(cols.toList, name)
+    
+    val colFiltered = if (ignoreList != null && ignoreList.size > 0) {
+      cols.filter(cd => !ignoreList.contains(cd.getName)).toList
+    } 
+    else {
+      cols.toList
+    }
+    
+    val connectSchema = convertToConnectSchema(colFiltered, name)
     val struct = new Struct(connectSchema)
-    cols.map(c => struct.put(c.getName, mapTypes(c, row))).head
+    colFiltered.map(c => struct.put(c.getName, mapTypes(c, row))).head
     struct
   }
 

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskSpecifyColumns.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskSpecifyColumns.scala
@@ -94,11 +94,68 @@ class TestCassandraSourceTaskSpecifyColumns extends WordSpec with Matchers with 
     val json: JsonNode = convertValueToJson(sourceRecord)
     println(json)
     json.get("string_field").asText().equals("magic_string") shouldBe true
+    json.get("timestamp_field").asText().size > 0
     json.get("int_field") shouldBe null
     //stop task
     task.stop()
   }
 
+  
+    "A Cassandra SourceTask should read only columns specified and ignore those specified" in {
+    val session = createTableAndKeySpace(secure = true, ssl = false)
+
+    val sql = s"INSERT INTO $CASSANDRA_KEYSPACE.$TABLE2" +
+      "(id, int_field, long_field, string_field, timestamp_field) " +
+      "VALUES ('id1', 2, 3, 'magic_string', now());"
+    session.execute(sql)
+
+    //wait for cassandra write a little
+    Thread.sleep(1000)
+
+    val taskContext = getSourceTaskContextDefault
+    //get config
+    val config = {
+      Map(
+        CassandraConfigConstants.CONTACT_POINTS -> CONTACT_POINT,
+        CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
+        CassandraConfigConstants.USERNAME -> USERNAME,
+        CassandraConfigConstants.PASSWD -> PASSWD,
+        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE2 IGNORE timestamp_field PK timestamp_field",
+        CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE2",
+        CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
+        CassandraConfigConstants.POLL_INTERVAL -> "1000").asJava
+    }
+
+    //get task
+    val task = new CassandraSourceTask()
+    //initialise the tasks context
+    task.initialize(taskContext)
+    //start task
+    task.start(config)
+
+    //trigger poll to have the readers execute a query and add to the queue
+    task.poll()
+
+    //wait a little for the poll to catch the records
+    while (task.queueSize(TABLE2) == 0) {
+      Thread.sleep(5000)
+    }
+
+    //call poll again to drain the queue
+    val records = task.poll()
+
+    val sourceRecord = records.asScala.head
+    //check a field
+    val json: JsonNode = convertValueToJson(sourceRecord)
+    println(json)
+    json.get("string_field").asText().equals("magic_string") shouldBe true
+    json.get("int_field") shouldBe null
+    json.get("timestamp_field") shouldBe null
+    //stop task
+    task.stop()
+  }
+  
+  
   "A Cassandra SourceTask should throw exception when timestamp column is not specified" in {
     val session = createTableAndKeySpace(secure = true, ssl = false)
 
@@ -132,6 +189,7 @@ class TestCassandraSourceTaskSpecifyColumns extends WordSpec with Matchers with 
     } catch {
       case _: ConfigException => // Expected, so continue
     }
+    task.stop()
   }
 }
 

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/TestSchemaConverter.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/TestSchemaConverter.scala
@@ -52,7 +52,8 @@ class TestSchemaConverter extends WordSpec with TestConfig with Matchers with Mo
     val cols = TestUtils.getColumnDefs
     when(row.getColumnDefinitions).thenReturn(cols)
     mockRow(row)
-    val sr: Struct = CassandraUtils.convert(row, "test", null)
+    val colDefList = CassandraUtils.getStructColumns(row, null)
+    val sr: Struct = CassandraUtils.convert(row, "test", colDefList)
     val schema = sr.schema()
     checkCols(schema)
     sr.get("timeuuidCol").toString shouldBe uuid.toString
@@ -67,8 +68,9 @@ class TestSchemaConverter extends WordSpec with TestConfig with Matchers with Mo
     mockRow(row)
 
     val ignoreList = List("intCol", "floatCol")
-
-    val sr: Struct = CassandraUtils.convert(row, "test", ignoreList)
+    val colDefList = CassandraUtils.getStructColumns(row, ignoreList)
+    val sr: Struct = CassandraUtils.convert(row, "test", colDefList)
+    
     sr.get("timeuuidCol").toString shouldBe uuid.toString
     sr.get("mapCol") shouldBe "{}"
 


### PR DESCRIPTION
This is mostly open for comments and discussion to further explore configuration to allow more flexibility in how the `SourceRecord` is created. This is based on our conversations over email.

This PR is a possible refactor that would allow withunwrap KCQL to be plugged into the Cassandra Source. Right now the `CassandraTableReader` (line 267) has a variable `withunwrap` set to false.
The idea would be to replace this line with 

```val withunwrap = settings.withunwrap```

when the KCQL is updated and if that is the route you decide to go. 
When this is true it would create a comma delimited list out of the column values.

This allows 

`SELECT colA, ts FROM event_table IGNORE ts PK ts `

to yield a String on the Kafka Topic that contains only the value of colA
