### PR TITLE
fixing timestamp null handling before formatting

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtils.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/utils/CassandraUtils.scala
@@ -119,7 +119,7 @@ object CassandraUtils {
       case DataType.Name.TIME => row.getTime(columnDef.getName)
       case DataType.Name.TIMESTAMP =>
         val timestamp: Date = row.getTimestamp(columnDef.getName)
-        dateFormatter.format(timestamp)
+        if (timestamp != null) dateFormatter.format(timestamp)
       case DataType.Name.TUPLE => row.getTupleValue(columnDef.getName).toString
       case DataType.Name.UDT => row.getUDTValue(columnDef.getName).toString
       case DataType.Name.TIMEUUID => row.getUUID(columnDef.getName).toString


### PR DESCRIPTION
fixing timestamp null handling before formatting, one use case was updated_on, if column is not available at first insert of the record and we are also trying to fetch and perform actions on it, it should be held null if null there as other columns.