### PR TITLE
ElasticSearch connector with date in index and custom document type

### DIFF
--- a/kafka-connect-elastic/build.gradle
+++ b/kafka-connect-elastic/build.gradle
@@ -17,8 +17,8 @@
 project(":kafka-connect-elastic") {
 
     ext {
-        elastic4sVersion = '2.1.0'
-        elasticVersion = '2.2.0'
+        elastic4sVersion = '2.4.0'
+        elasticVersion = '2.4.5'
         jnaVersion = '3.0.9'
     }
 

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticJsonWriter.scala
@@ -25,7 +25,7 @@ import com.sksamuel.elastic4s.source.Indexable
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.sink.SinkRecord
-import org.elasticsearch.action.bulk.BulkResponse
+import com.sksamuel.elastic4s.BulkResult
 
 import scala.collection.immutable.Iterable
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -87,7 +87,7 @@ class ElasticJsonWriter(client: ElasticClient, settings: ElasticSettings) extend
     *
     * @param records A list of SinkRecords
     * */
-  def insert(records: Map[String, Set[SinkRecord]]) : Iterable[Future[BulkResponse]] = {
+  def insert(records: Map[String, Set[SinkRecord]]) : Iterable[Future[BulkResult]] = {
     val ret = records.map({
       case (topic, sinkRecords) =>
         val fields = settings.fields(topic)

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticJsonWriter.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticJsonWriter.scala
@@ -30,10 +30,18 @@ import org.elasticsearch.action.bulk.BulkResponse
 import scala.collection.immutable.Iterable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import com.datamountaineer.streamreactor.connect.elastic.indexname.CustomIndexName
 
 class ElasticJsonWriter(client: ElasticClient, settings: ElasticSettings) extends StrictLogging with ConverterUtil {
   logger.info("Initialising Elastic Json writer")
-  createIndexes()
+
+  import ElasticJsonWriter.createIndexName
+
+  val createIndexNameWithSuffix = createIndexName(settings.indexNameSuffix) _
+
+  if (settings.indexAutoCreate) {
+    createIndexes()
+  }
 
   implicit object SinkRecordIndexable extends Indexable[SinkRecord] {
     override def json(t: SinkRecord): String = convertValueToJson(t).toString
@@ -44,7 +52,12 @@ class ElasticJsonWriter(client: ElasticClient, settings: ElasticSettings) extend
     *
     * */
   private def createIndexes() : Unit = {
-   settings.tableMap.map({ case(_,v) => client.execute( { create index v.toLowerCase() })})
+   settings.tableMap.map({ case(topicName, indexName) => client.execute( {
+     settings.documentType match {
+       case Some(documentType) => create index createIndexNameWithSuffix(indexName) mappings documentType
+       case _ => create index createIndexNameWithSuffix(indexName)
+     }
+   })})
   }
 
   /**
@@ -79,13 +92,14 @@ class ElasticJsonWriter(client: ElasticClient, settings: ElasticSettings) extend
       case (topic, sinkRecords) =>
         val fields = settings.fields(topic)
         val ignoreFields = settings.ignoreFields(topic)
-        val i = settings.tableMap(topic)
+        val i = createIndexNameWithSuffix(settings.tableMap(topic))
+        val documentType = settings.documentType.getOrElse(i)
 
         val indexes = sinkRecords
                         .map(r => convert(r, fields, ignoreFields))
                         .map { r =>
                           configMap(r.topic).getWriteMode match {
-                            case WriteModeEnum.INSERT => index into i.toLowerCase / i source r
+                            case WriteModeEnum.INSERT => index into i / documentType source r
                             case WriteModeEnum.UPSERT =>
                               // Build a Struct field extractor to get the value from the PK field
                               val pkField = settings.pks(r.topic)
@@ -93,7 +107,7 @@ class ElasticJsonWriter(client: ElasticClient, settings: ElasticSettings) extend
                               val extractor = StructFieldsExtractor(includeAllFields = true, Map(pkField -> pkField))
                               val fieldsAndValues = extractor.get(r.value.asInstanceOf[Struct]).toMap
                               val pkValue = fieldsAndValues(pkField).toString
-                              update id pkValue in i.toLowerCase / i docAsUpsert fieldsAndValues
+                              update id pkValue in i / documentType docAsUpsert fieldsAndValues
                           }
                         }
 
@@ -110,4 +124,9 @@ class ElasticJsonWriter(client: ElasticClient, settings: ElasticSettings) extend
     })
     ret
   }
+}
+
+private object ElasticJsonWriter {
+  def createIndexName(maybeIndexNameSuffix: Option[String])(indexName: String): String =
+    maybeIndexNameSuffix.fold(indexName) { indexNameSuffix => s"$indexName${CustomIndexName.parseIndexName(indexNameSuffix)}" }
 }

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticWriter.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/ElasticWriter.scala
@@ -21,7 +21,7 @@ import com.sksamuel.elastic4s.{ElasticClient, ElasticsearchClientUri}
 import org.apache.kafka.connect.sink.SinkTaskContext
 import org.elasticsearch.common.settings.Settings
 
-object  ElasticWriter {
+object ElasticWriter {
   /**
     * Construct a JSONWriter.
     *

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSettings.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSettings.scala
@@ -28,9 +28,15 @@ case class ElasticSettings(routes: List[Config],
                            fields : Map[String, Map[String, String]],
                            ignoreFields: Map[String, Set[String]],
                            pks: Map[String, String],
-                           tableMap: Map[String, String])
+                           tableMap: Map[String, String],
+                           indexNameSuffix: Option[String],
+                           indexAutoCreate: Boolean,
+                           documentType: Option[String])
 
 object ElasticSettings {
+
+  private def toOption(configValue: String) = if (configValue.nonEmpty) Some(configValue) else None
+
   def apply(config: ElasticSinkConfig): ElasticSettings = {
     val raw = config.getString(ElasticSinkConfigConstants.EXPORT_ROUTE_QUERY)
     require(!raw.isEmpty,s"Empty ${ElasticSinkConfigConstants.EXPORT_ROUTE_QUERY_DOC}")
@@ -51,6 +57,14 @@ object ElasticSettings {
         (r.getSource, keys.head)
       }.toMap
 
-    ElasticSettings(routes = routes, fields = fields,ignoreFields = ignoreFields, pks = pks, tableMap = tableMap)
+    ElasticSettings(routes = routes,
+                    fields = fields,
+                    ignoreFields = ignoreFields,
+                    pks = pks,
+                    tableMap = tableMap,
+                    indexNameSuffix = toOption(config.getString(ElasticSinkConfigConstants.INDEX_NAME_SUFFIX)),
+                    indexAutoCreate = config.getBoolean(ElasticSinkConfigConstants.AUTO_CREATE_INDEX),
+                    documentType = toOption(config.getString(ElasticSinkConfigConstants.DOCUMENT_TYPE))
+    )
   }
 }

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSettings.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSettings.scala
@@ -35,8 +35,6 @@ case class ElasticSettings(routes: List[Config],
 
 object ElasticSettings {
 
-  private def toOption(configValue: String) = if (configValue.nonEmpty) Some(configValue) else None
-
   def apply(config: ElasticSinkConfig): ElasticSettings = {
     val raw = config.getString(ElasticSinkConfigConstants.EXPORT_ROUTE_QUERY)
     require(!raw.isEmpty,s"Empty ${ElasticSinkConfigConstants.EXPORT_ROUTE_QUERY_DOC}")
@@ -62,9 +60,9 @@ object ElasticSettings {
                     ignoreFields = ignoreFields,
                     pks = pks,
                     tableMap = tableMap,
-                    indexNameSuffix = toOption(config.getString(ElasticSinkConfigConstants.INDEX_NAME_SUFFIX)),
+                    indexNameSuffix = Option(config.getString(ElasticSinkConfigConstants.INDEX_NAME_SUFFIX)),
                     indexAutoCreate = config.getBoolean(ElasticSinkConfigConstants.AUTO_CREATE_INDEX),
-                    documentType = toOption(config.getString(ElasticSinkConfigConstants.DOCUMENT_TYPE))
+                    documentType = Option(config.getString(ElasticSinkConfigConstants.DOCUMENT_TYPE))
     )
   }
 }

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSinkConfig.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSinkConfig.scala
@@ -36,6 +36,11 @@ object ElasticSinkConfig {
     .define(ElasticSinkConfigConstants.EXPORT_ROUTE_QUERY, Type.STRING, Importance.HIGH,
       ElasticSinkConfigConstants.EXPORT_ROUTE_QUERY_DOC, "Target", 1, ConfigDef.Width.LONG,
       ElasticSinkConfigConstants.EXPORT_ROUTE_QUERY)
+    .define(ElasticSinkConfigConstants.INDEX_NAME_SUFFIX, Type.STRING, ElasticSinkConfigConstants.INDEX_NAME_SUFFIX_DEFAULT,
+        Importance.LOW, ElasticSinkConfigConstants.INDEX_NAME_SUFFIX_DOC, "Target", 2, ConfigDef.Width.MEDIUM, ElasticSinkConfigConstants.INDEX_NAME_SUFFIX)
+    .define(ElasticSinkConfigConstants.AUTO_CREATE_INDEX, Type.BOOLEAN, ElasticSinkConfigConstants.AUTO_CREATE_INDEX_DEFAULT,
+        Importance.LOW, ElasticSinkConfigConstants.AUTO_CREATE_INDEX_DOC, "Target", 3, ConfigDef.Width.MEDIUM, ElasticSinkConfigConstants.AUTO_CREATE_INDEX)
+    .define(ElasticSinkConfigConstants.DOCUMENT_TYPE, Type.STRING, ElasticSinkConfigConstants.DOCUMENT_TYPE_DEFAULT, Importance.LOW, ElasticSinkConfigConstants.DOCUMENT_TYPE_DOC, "Target", 4, ConfigDef.Width.MEDIUM, ElasticSinkConfigConstants.DOCUMENT_TYPE)
 }
 
 /**

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSinkConfigConstants.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSinkConfigConstants.scala
@@ -29,4 +29,16 @@ object ElasticSinkConfigConstants {
   val URL_PREFIX_DEFAULT = "elasticsearch"
   val EXPORT_ROUTE_QUERY = "connect.elastic.sink.kcql"
   val EXPORT_ROUTE_QUERY_DOC = "KCQL expression describing field selection and routes."
+
+  val INDEX_NAME_SUFFIX = "connect.elastic.index.suffix"
+  val INDEX_NAME_SUFFIX_DOC = "Suffix to append to the index name. Supports date time notation inside curly brackets. E.g. 'abc_{YYYY-MM-dd}_def'"
+  val INDEX_NAME_SUFFIX_DEFAULT = ""
+
+  val AUTO_CREATE_INDEX = "connect.elastic.index.auto.create"
+  val AUTO_CREATE_INDEX_DOC = "The flag enables/disables auto creating the ElasticSearch index. Boolean value required. Defaults to TRUE."
+  val AUTO_CREATE_INDEX_DEFAULT = true
+
+  val DOCUMENT_TYPE = "connect.elastic.document.type"
+  val DOCUMENT_TYPE_DOC = "Sets the ElasticSearch document type. See https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-type-field.html for more info."
+  val DOCUMENT_TYPE_DEFAULT = ""
 }

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSinkConfigConstants.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/config/ElasticSinkConfigConstants.scala
@@ -32,7 +32,7 @@ object ElasticSinkConfigConstants {
 
   val INDEX_NAME_SUFFIX = "connect.elastic.index.suffix"
   val INDEX_NAME_SUFFIX_DOC = "Suffix to append to the index name. Supports date time notation inside curly brackets. E.g. 'abc_{YYYY-MM-dd}_def'"
-  val INDEX_NAME_SUFFIX_DEFAULT = ""
+  val INDEX_NAME_SUFFIX_DEFAULT: String = null
 
   val AUTO_CREATE_INDEX = "connect.elastic.index.auto.create"
   val AUTO_CREATE_INDEX_DOC = "The flag enables/disables auto creating the ElasticSearch index. Boolean value required. Defaults to TRUE."
@@ -40,5 +40,5 @@ object ElasticSinkConfigConstants {
 
   val DOCUMENT_TYPE = "connect.elastic.document.type"
   val DOCUMENT_TYPE_DOC = "Sets the ElasticSearch document type. See https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-type-field.html for more info."
-  val DOCUMENT_TYPE_DEFAULT = ""
+  val DOCUMENT_TYPE_DEFAULT: String = null
 }

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/CustomIndexName.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/CustomIndexName.scala
@@ -1,0 +1,37 @@
+package com.datamountaineer.streamreactor.connect.elastic.indexname
+
+import scala.annotation.tailrec
+
+class InvalidCustomIndexNameException(message: String) extends RuntimeException(message)
+
+case class CustomIndexName(fragments: Vector[IndexNameFragment]) {
+  override def toString = fragments.map(_.getFragment).mkString
+}
+
+object CustomIndexName {
+
+  @tailrec
+  private def parseIndexName(remainingChars: Vector[Char], currentFragment: StringBuilder, results: Vector[Option[IndexNameFragment]]): Vector[IndexNameFragment] =
+    remainingChars match {
+      case head +: rest => head match {
+        case DateTimeFragment.OpeningChar =>
+          val (dateTimeFormat, afterDateTimeFormatIncludingClosingChar) = rest.span { _ != DateTimeFragment.ClosingChar }
+          val afterDateTimeFormat = afterDateTimeFormatIncludingClosingChar.tail
+
+          val maybeCurrentFragment = currentFragment.mkString.toOption
+          val maybeDateTimeFormat = dateTimeFormat.mkString.toOption
+
+          val newResultsWithDateTimeFragment = results :+ maybeCurrentFragment.map(TextFragment.apply) :+ maybeDateTimeFormat.map(DateTimeFragment(_))
+
+          parseIndexName(afterDateTimeFormat, new StringBuilder, newResultsWithDateTimeFragment)
+        case DateTimeFragment.ClosingChar => throw new InvalidCustomIndexNameException(s"Found closing '${DateTimeFragment.ClosingChar}' but no opening character")
+        case anyOtherChar => parseIndexName(rest, currentFragment.append(anyOtherChar), results)
+      }
+      case Vector() =>
+        val maybeCurrentFragment = currentFragment.mkString.toOption
+        (results :+ maybeCurrentFragment.map(TextFragment.apply)).flatten
+    }
+
+  def parseIndexName(indexName: String): CustomIndexName =
+    CustomIndexName(parseIndexName(indexName.toVector, new StringBuilder, Vector.empty))
+}

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/IndexNameFragment.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/IndexNameFragment.scala
@@ -1,0 +1,25 @@
+package com.datamountaineer.streamreactor.connect.elastic.indexname
+
+import java.time.Clock
+import java.time.LocalDateTime._
+import java.time.format.DateTimeFormatter._
+
+object ClockProvider {
+  val ClockInstance = Clock.systemUTC()
+}
+
+sealed trait IndexNameFragment {
+  def getFragment: String
+}
+
+case class TextFragment(text: String) extends IndexNameFragment {
+  override def getFragment: String = text
+}
+
+case class DateTimeFragment(dateTimeFormat: String, clock: Clock = ClockProvider.ClockInstance) extends IndexNameFragment {
+  override def getFragment: String = s"${now(clock).format(ofPattern(dateTimeFormat))}"
+}
+object DateTimeFragment {
+  val OpeningChar = '{'
+  val ClosingChar = '}'
+}

--- a/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/package.scala
+++ b/kafka-connect-elastic/src/main/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/package.scala
@@ -1,0 +1,8 @@
+package com.datamountaineer.streamreactor.connect.elastic
+
+package object indexname {
+
+  implicit class StringToOption(text: String) {
+    def toOption: Option[String] = if (text.nonEmpty) Some(text) else None
+  }
+}

--- a/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticBase.scala
+++ b/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticBase.scala
@@ -16,7 +16,7 @@
 
 package com.datamountaineer.streamreactor.connect.elastic
 
-import java.time.{Instant, LocalDateTime}
+import java.time.LocalDateTime
 import java.util
 
 import com.datamountaineer.streamreactor.connect.elastic.config.ElasticSinkConfigConstants
@@ -28,8 +28,6 @@ import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.reflect.io.File
-import java.time.LocalDateTime._
 import java.time.format.DateTimeFormatter._
 
 trait TestElasticBase extends WordSpec with Matchers with BeforeAndAfter {
@@ -132,13 +130,11 @@ trait TestElasticBase extends WordSpec with Matchers with BeforeAndAfter {
       ElasticSinkConfigConstants.URL->ELASTIC_SEARCH_HOSTNAMES,
       ElasticSinkConfigConstants.ES_CLUSTER_NAME->ElasticSinkConfigConstants.ES_CLUSTER_NAME_DEFAULT,
       ElasticSinkConfigConstants.URL_PREFIX->ElasticSinkConfigConstants.URL_PREFIX_DEFAULT,
-      ElasticSinkConfigConstants.EXPORT_ROUTE_QUERY->query,
-      ElasticSinkConfigConstants.INDEX_NAME_SUFFIX->"_{YYYY-MM-dd}",
-      ElasticSinkConfigConstants.DOCUMENT_TYPE->"sample_document"
+      ElasticSinkConfigConstants.EXPORT_ROUTE_QUERY->query
     ).asJava
   }
 
-  def getElasticSinkConfigPropsWithIndexAutoCreation(autoCreate: Boolean) = {
+  def getElasticSinkConfigPropsWithDateSuffixAndIndexAutoCreation(autoCreate: Boolean) = {
     Map (
       ElasticSinkConfigConstants.URL->ELASTIC_SEARCH_HOSTNAMES,
       ElasticSinkConfigConstants.ES_CLUSTER_NAME->ElasticSinkConfigConstants.ES_CLUSTER_NAME_DEFAULT,

--- a/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticJsonWriter.scala
+++ b/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticJsonWriter.scala
@@ -1,0 +1,17 @@
+package com.datamountaineer.streamreactor.connect.elastic
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class TestElasticJsonWriter extends FlatSpec with Matchers {
+  "ElasticJsonWriter" should "create an index name without suffix when suffix not set" in {
+    ElasticJsonWriter.createIndexName(None)("index_name") shouldBe "index_name"
+  }
+
+  it should "create an index name with suffix when suffix is set" in {
+    val formattedDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd"))
+    ElasticJsonWriter.createIndexName(Some("_suffix_{YYYY-MM-dd}"))("index_name") shouldBe s"index_name_suffix_$formattedDateTime"
+  }
+}

--- a/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticWriter.scala
+++ b/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/TestElasticWriter.scala
@@ -56,7 +56,7 @@ class TestElasticWriter extends TestElasticBase with MockitoSugar {
 
     Thread.sleep(2000)
     //check counts
-    val res = client.execute { search in INDEX }.await
+    val res = client.execute { search in INDEX_WITH_DATE }.await
     res.totalHits shouldBe testRecords.size
     //close writer
     writer.close()
@@ -86,7 +86,7 @@ class TestElasticWriter extends TestElasticBase with MockitoSugar {
 
     Thread.sleep(2000)
     //check counts
-    val res = client.execute { search in INDEX }.await
+    val res = client.execute { search in INDEX_WITH_DATE }.await
     res.totalHits shouldBe testRecords.size
 
     val testUpdateRecords = getUpdateTestRecord
@@ -96,7 +96,7 @@ class TestElasticWriter extends TestElasticBase with MockitoSugar {
 
     Thread.sleep(2000)
     //check counts
-    val updateRes = client.execute { search in INDEX }.await
+    val updateRes = client.execute { search in INDEX_WITH_DATE }.await
     updateRes.totalHits shouldBe testRecords.size
 
     //close writer

--- a/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/ClockFixture.scala
+++ b/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/ClockFixture.scala
@@ -1,0 +1,7 @@
+package com.datamountaineer.streamreactor.connect.elastic.indexname
+
+import java.time.{Clock, Instant, ZoneOffset}
+
+trait ClockFixture {
+  val TestClock = Clock.fixed(Instant.parse("2016-10-02T14:00:00.00Z"), ZoneOffset.UTC)
+}

--- a/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/TestCustomIndexName.scala
+++ b/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/TestCustomIndexName.scala
@@ -1,0 +1,48 @@
+package com.datamountaineer.streamreactor.connect.elastic.indexname
+
+import org.scalatest.prop.{GeneratorDrivenPropertyChecks, TableDrivenPropertyChecks}
+import org.scalatest.{FlatSpec, Matchers}
+
+class TestCustomIndexName extends FlatSpec with TableDrivenPropertyChecks with GeneratorDrivenPropertyChecks with Matchers {
+
+  val ValidIndexNames = Table(
+    ("Valid index name", "Expectations"),
+    ("", Vector()),
+    ("abc", Vector(TextFragment("abc"))),
+    ("abc{YYYY-MM-dd}", Vector(TextFragment("abc"), DateTimeFragment("YYYY-MM-dd"))),
+    ("{YYYY-MM-dd}abc", Vector(DateTimeFragment("YYYY-MM-dd"), TextFragment("abc"))),
+    ("{YYYY-MM-dd}abc{HH-MM-ss}", Vector(DateTimeFragment("YYYY-MM-dd"), TextFragment("abc"), DateTimeFragment("HH-MM-ss"))),
+    ("{YYYY-MM-dd}{HH-MM-ss}", Vector(DateTimeFragment("YYYY-MM-dd"), DateTimeFragment("HH-MM-ss"))),
+    ("abc{}", Vector(TextFragment("abc"))),
+    ("{}abc", Vector(TextFragment("abc")))
+  )
+
+  val InvalidIndexNames = Table(
+    ("Invalid index name"),
+    ("}abc"),
+    ("abc}"),
+    ("abc}def")
+  )
+
+  "Custom index name" should "parse a valid String with date time formatting options" in {
+    forAll (ValidIndexNames) { case (validIndexName, expectations) =>
+      CustomIndexName.parseIndexName(validIndexName) shouldBe CustomIndexName(expectations)
+    }
+  }
+
+  it should "throw an exception when using invalid index name" in {
+    forAll (InvalidIndexNames) { case (invalidIndexName) =>
+      intercept[InvalidCustomIndexNameException] {
+        CustomIndexName.parseIndexName(invalidIndexName)
+      }
+    }
+  }
+
+  it should "return a valid String from a list of fragments" in new ClockFixture {
+    CustomIndexName(
+      Vector(DateTimeFragment("YYYY-MM-dd", TestClock),
+        TextFragment("ABC"),
+        DateTimeFragment("HH:mm:ss", TestClock))
+    ).toString shouldBe "2016-10-02ABC14:00:00"
+  }
+}

--- a/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/TestIndexNameFragment.scala
+++ b/kafka-connect-elastic/src/test/scala/com/datamountaineer/streamreactor/connect/elastic/indexname/TestIndexNameFragment.scala
@@ -1,0 +1,20 @@
+package com.datamountaineer.streamreactor.connect.elastic.indexname
+
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class TestIndexNameFragment extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  "TextFragment" should "return the original text when using getFragment()" in {
+    forAll(Gen.alphaStr) { someString =>
+      TextFragment(someString).getFragment shouldBe someString
+    }
+  }
+
+  "DateTimeFragment" should "return the formatted date when using getFragment()" in new ClockFixture {
+    val dateTimeFormat = "YYYY-MM-dd HH:mm:ss"
+    val expectedResult = "2016-10-02 14:00:00"
+    DateTimeFragment(dateTimeFormat, TestClock).getFragment shouldBe expectedResult
+  }
+}


### PR DESCRIPTION
The ElasticSearch connector is updated with:

- support for auto-generated time/date in index names; this is to create indexes per day instead of one ever-increasing index, as per the official guidelines on [Retiring Data](https://www.elastic.co/guide/en/elasticsearch/guide/current/retiring-data.html)
- support for custom document type for the messages to be saved; document types allow custom indexing policies 