### PR TITLE
Cassandra Source: use paging technique to avoid ALLOW FILTER

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ allprojects {
         json4sVersion = "3.3.0"
         kiteMiniClusterVersion = "1.1.0"
         gsonVersion = "2.6.2"
-        dataMountaineerKCQLVersion = "1.0.1"
+        dataMountaineerKCQLVersion = "1.0.3"
         akkaVersion = "2.4.10"
         connectCLIVersion = "1.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ allprojects {
         json4sVersion = "3.3.0"
         kiteMiniClusterVersion = "1.1.0"
         gsonVersion = "2.6.2"
-        dataMountaineerKCQLVersion = "1.0.0"
+        dataMountaineerKCQLVersion = "1.0.1"
         akkaVersion = "2.4.10"
         connectCLIVersion = "1.0"
 

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -62,6 +62,7 @@ class CassandraTableReader(private val session: Session,
   private val topic = config.getTarget
   private val keySpace = setting.keySpace
   // TODO: need two different statements for token (with no offset and with an offset)
+  // private val preparedStatementNoOffset ??
   private val preparedStatement = getPreparedStatements
   // TODO: make offset handling generic (not date based)
   private var tableOffset: Option[Date] = buildOffsetMap(context)

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -48,17 +48,22 @@ class CassandraTableReader(private val session: Session,
                            private val context: SourceTaskContext,
                            var queue: LinkedBlockingQueue[SourceRecord]) extends StrictLogging {
 
+
+  private val config = setting.routes
+  private val cqlGenerator = new CqlGenerator(setting)
+  
   private val defaultTimestamp = "1900-01-01 00:00:00.0000000Z"
   private val dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS'Z'")
-  private val timestampCol = setting.timestampColumn.getOrElse("")
+  private val timestampCol = setting.primaryKeyColumn.getOrElse("")
   private val querying = new AtomicBoolean(false)
   private val stop = new AtomicBoolean(false)
   private var lastPoll = 0.toLong
-  private val table = setting.routes.getSource
-  private val topic = setting.routes.getTarget
+  private val table = config.getSource
+  private val topic = config.getTarget
   private val keySpace = setting.keySpace
-  private val selectColumns = getSelectColumns
+  // TODO: need two different statements for token (with no offset and with an offset)
   private val preparedStatement = getPreparedStatements
+  // TODO: make offset handling generic (not date based)
   private var tableOffset: Option[Date] = buildOffsetMap(context)
   private val sourcePartition = Collections.singletonMap(CassandraConfigConstants.ASSIGNED_TABLES, table)
   private val schemaName = s"$keySpace.$table".replace('-', '.')
@@ -84,44 +89,10 @@ class CassandraTableReader(private val session: Session,
     * @return the PreparedStatement
     */
   private def getPreparedStatements: PreparedStatement = {
-    // if we are in incremental mode
-    // we need to have the time stamp column
-    if (!setting.bulkImportMode) {
-      if (!selectColumns.contains(timestampCol) && !selectColumns.contentEquals("*")) {
-        val msg = s"the timestamp column ($timestampCol) must appear in the SELECT statement"
-        logger.error(msg)
-        throw new ConfigException(msg)
-      }
-    }
-
-    // build the correct CQL statement based on the KCQL
-    val selectStatement = if (setting.bulkImportMode) {
-      s"SELECT $selectColumns FROM $keySpace.$table"
-    } else {
-      val predicate = setting.timestampColType match {
-        case TimestampType.TIMEUUID => s"WHERE $timestampCol > maxTimeuuid(?) AND $timestampCol <= minTimeuuid(?) ALLOW FILTERING"
-        case TimestampType.TIMESTAMP => s"WHERE $timestampCol > ? AND $timestampCol <= ? ALLOW FILTERING"
-      }
-      s"SELECT $selectColumns FROM $keySpace.$table $predicate"
-    }
-
+    val selectStatement = cqlGenerator.getCqlStatement
     val statement = session.prepare(selectStatement)
     setting.consistencyLevel.foreach(statement.setConsistencyLevel)
     statement
-  }
-
-  /**
-    * get the columns for the SELECT statement
-    *
-    * @return the comma separated columns
-    */
-  private def getSelectColumns: String = {
-    val faList = setting.routes.getFieldAlias.map(fa => fa.getField).toList
-
-    //if no columns set then select the whole table
-    val f = if (faList == null || faList.isEmpty) "*" else faList.mkString(",")
-    logger.info(s"the fields to select are $f")
-    f
   }
 
   /**
@@ -252,7 +223,7 @@ class CassandraTableReader(private val session: Session,
     */
   private def processRow(row: Row) = {
     // convert the cassandra row to a struct
-    val ignoreList = setting.routes.getIgnoredField.toList
+    val ignoreList = config.getIgnoredField.toList
     val structColDefs = CassandraUtils.getStructColumns(row, ignoreList)
     val struct = CassandraUtils.convert(row, schemaName, structColDefs)
 
@@ -263,7 +234,7 @@ class CassandraTableReader(private val session: Session,
     logger.debug(s"Storing offset $offset")
 
     // create source record
-    val record = if (setting.routes.isWithUnwrap) {
+    val record = if (config.isWithUnwrap) {
       val structValue = structColDefs.map(d => d.getName).map(name => row.getObject(name)).mkString(",")
       new SourceRecord(sourcePartition, Map(timestampCol -> offset), topic, Schema.STRING_SCHEMA, structValue)
     } else {
@@ -286,9 +257,9 @@ class CassandraTableReader(private val session: Session,
     * @return A java.util.Date
     */
   private def extractTimestamp(row: Row): Date = {
-    Try(row.getTimestamp(setting.timestampColumn.get)) match {
+    Try(row.getTimestamp(setting.primaryKeyColumn.get)) match {
       case Success(s) => s
-      case Failure(_) => new Date(UUIDs.unixTimestamp(row.getUUID(setting.timestampColumn.get)))
+      case Failure(_) => new Date(UUIDs.unixTimestamp(row.getUUID(setting.primaryKeyColumn.get)))
     }
   }
 
@@ -299,7 +270,7 @@ class CassandraTableReader(private val session: Session,
     */
   private def reset(offset: Option[Date]) = {
     //set the offset to the 'now' bind value
-    val table = setting.routes.getTarget
+    val table = config.getTarget
     logger.debug(s"Setting offset for $keySpace.$table to $offset.")
     tableOffset = offset.orElse(tableOffset)
     //switch to not querying
@@ -320,7 +291,7 @@ class CassandraTableReader(private val session: Session,
     * Tell me to stop processing.
     */
   def stopQuerying(): Unit = {
-    val table = setting.routes.getTarget
+    val table = config.getTarget
     stop.set(true)
     while (querying.get()) {
       logger.info(s"Waiting for querying to stop for $keySpace.$table.")

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -1,0 +1,111 @@
+package com.datamountaineer.streamreactor.connect.cassandra.source
+
+import com.datamountaineer.connector.config.Config
+import com.datamountaineer.connector.config.FieldAlias
+import com.datastax.driver.core.PreparedStatement
+import com.typesafe.scalalogging.slf4j.StrictLogging
+
+import scala.collection.JavaConversions._
+import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraSourceSetting
+import org.apache.kafka.common.config.ConfigException
+import com.datamountaineer.streamreactor.connect.cassandra.config.TimestampType
+
+class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLogging {
+
+  private val config = setting.routes
+  private val table = config.getSource
+  private val keySpace = setting.keySpace
+  private val selectColumns = getSelectColumns
+  private val incrementMode = determineMode
+  private val limitRowsSize = 100
+
+  /**
+   * Build the CQL for the given table.
+   *
+   * @return the CQL statement (as a String)
+   */
+  def getCqlStatement: String = {
+
+    // build the correct CQL statement based on the KCQL mode
+    val selectStatement = if (setting.bulkImportMode) {
+      generateCqlForBulkMode
+    } else {
+      // if we are not in bulk mode 
+      // we must be in incremental mode
+      logger.info(s"the increment mode is $incrementMode")
+      incrementMode.toUpperCase match {
+        case "TIMEUUID" => generateCqlForTimeUuidMode
+        case "TIMESTAMP" => generateCqlForTimestampMode
+        case "TOKEN" => generateCqlForTokenMode
+        case _ => throw new ConfigException(s"unknown incremental mode ($incrementMode)")
+      }
+    }
+    logger.info(s"generated CQL: $selectStatement")
+    selectStatement
+  }
+
+  /**
+   * get the columns for the SELECT statement
+   *
+   * @return the comma separated columns
+   */
+  private def getSelectColumns(): String = {
+    val fieldList = config.getFieldAlias.map(fa => fa.getField).toList
+    // if no columns set then select all the columns in the table
+    val selectColumns = if (fieldList == null || fieldList.isEmpty) "*" else fieldList.mkString(",")
+    logger.info(s"the fields to select are $selectColumns")
+    selectColumns
+  }
+
+  private def checkCqlForPrimaryKey(pkCol:String) = {
+    logger.info(s"checking CQL for PK: $pkCol")
+    if (!selectColumns.contains(pkCol) && !selectColumns.contentEquals("*")) {
+        val msg = s"the primary key column (pkCol) must appear in the SELECT statement"
+        logger.error(msg)
+        throw new ConfigException(msg)
+      }
+  }
+  
+  private def generateCqlForTokenMode: String = {
+    val pkCol = setting.primaryKeyColumn.getOrElse("")
+    checkCqlForPrimaryKey(pkCol)
+    val whereClause =  s" WHERE token($pkCol) > token(?) LIMIT $limitRowsSize"
+    generateCqlForBulkMode + whereClause
+  }
+  
+  private def generateCqlForTimeUuidMode: String = {
+    val pkCol = setting.primaryKeyColumn.getOrElse("")
+    checkCqlForPrimaryKey(pkCol)
+    val whereClause =  s" WHERE $pkCol > maxTimeuuid(?) AND $pkCol <= minTimeuuid(?) ALLOW FILTERING"
+    generateCqlForBulkMode + whereClause
+  }
+  
+  private def generateCqlForTimestampMode: String = {
+    val pkCol = setting.primaryKeyColumn.getOrElse("")
+    checkCqlForPrimaryKey(pkCol)
+    val whereClause =  s" WHERE $pkCol > ? AND $pkCol <= ? ALLOW FILTERING"
+    generateCqlForBulkMode + whereClause
+  }
+
+  private def generateCqlForBulkMode: String = {
+    s"SELECT $selectColumns FROM $keySpace.$table"
+  }
+  
+  /**
+   * determine the incremental mode in use
+   * if the INCREMENTALMODE is used in KCQL it 
+   * will take precedence over the configuration 
+   * setting
+   * 
+   * @return the incremental mode 
+   */
+  private def determineMode: String = {
+    val incMode = if (config.getIncrementalMode != null && !config.getIncrementalMode.isEmpty) {
+      config.getIncrementalMode.toUpperCase()
+    } else {
+      setting.timestampColType.toString()
+    }
+    incMode
+  }
+
+}

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -17,7 +17,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
   private val keySpace = setting.keySpace
   private val selectColumns = getSelectColumns
   private val incrementMode = determineMode
-  private val limitRowsSize = 100
+  private val limitRowsSize = config.getBatchSize
 
   /**
    * Build the CQL for the given table.

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Datamountaineer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datamountaineer.streamreactor.connect.cassandra.source
+
+import java.util.concurrent.LinkedBlockingQueue
+
+import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
+import com.datamountaineer.streamreactor.connect.cassandra.config.{ CassandraConfigSource, CassandraSettings }
+import com.datamountaineer.streamreactor.connect.queues.QueueHelpers
+import com.datamountaineer.streamreactor.connect.schemas.ConverterUtil
+import com.fasterxml.jackson.databind.JsonNode
+import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.source.SourceRecord
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ BeforeAndAfter, Matchers, WordSpec }
+
+import scala.collection.JavaConverters._
+import org.apache.kafka.common.config.ConfigException
+import org.apache.kafka.common.config.Config
+import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigConstants
+import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraSourceSetting
+
+/**
+ *
+ */
+class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with MockitoSugar with TestConfig
+    with ConverterUtil {
+
+  "CqlGenerator should generate timeuuid statement based on config" in {
+
+    val cqlGenerator = new CqlGenerator(configureMe("", "timeuuid"))
+    val cqlStatement = cqlGenerator.getCqlStatement
+
+    cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE timestamp_field > maxTimeuuid(?) AND timestamp_field <= minTimeuuid(?) ALLOW FILTERING"
+  }
+
+  "CqlGenerator should generate timestamp statement based on KCQL" in {
+
+    val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=timestamp", "timeuuid"))
+    val cqlStatement = cqlGenerator.getCqlStatement
+
+    cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE timestamp_field > ? AND timestamp_field <= ? ALLOW FILTERING"
+  }
+
+  "Exception should be thrown with unknown incremental mode in KCQL" in {
+
+    try {
+      val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=bogus", "timeuuid"))
+      cqlGenerator.getCqlStatement
+      fail()
+    } catch {
+      case _: ConfigException => // Expected, so continue
+    }
+  }
+
+  "Exception should be thrown with unknown incremental mode in config" in {
+
+    try {
+      val cqlGenerator = new CqlGenerator(configureMe("", "bogus"))
+      cqlGenerator.getCqlStatement
+      fail()
+    } catch {
+      case _: NoSuchElementException => // Expected, so continue
+    }
+  }
+
+  def configureMe(kcqlIncrementMode: String, configIncrementMode: String): CassandraSourceSetting = {
+    val myKcql = s"INSERT INTO kafka-topic SELECT string_field, timestamp_field FROM cassandra-table PK timestamp_field $kcqlIncrementMode"
+    val configMap = {
+      Map(
+        CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
+        CassandraConfigConstants.SOURCE_KCQL_QUERY -> myKcql,
+        CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE3",
+        CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
+        CassandraConfigConstants.POLL_INTERVAL -> "1000",
+        CassandraConfigConstants.TIMESTAMP_TYPE -> configIncrementMode).asJava
+    }
+    val configSource = new CassandraConfigSource(configMap)
+    CassandraSettings.configureSource(configSource).head
+  }
+
+}

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -56,6 +56,14 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
     cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE timestamp_field > ? AND timestamp_field <= ? ALLOW FILTERING"
   }
 
+  "CqlGenerator should generate token statement based on KCQL" in {
+
+    val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=token", "timeuuid"))
+    val cqlStatement = cqlGenerator.getCqlStatement
+
+    cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE token(timestamp_field) > token(?) LIMIT 200"
+  }
+
   "Exception should be thrown with unknown incremental mode in KCQL" in {
 
     try {
@@ -87,6 +95,7 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE3",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000",
+        CassandraConfigConstants.BATCH_SIZE -> "200",
         CassandraConfigConstants.TIMESTAMP_TYPE -> configIncrementMode).asJava
     }
     val configSource = new CassandraConfigSource(configMap)


### PR DESCRIPTION
This is the initial outline of the approach to page through results using token of the partition key, thus enabling CQL that does not require ALLOW FILTER. 

http://docs.datastax.com/en/cql/3.1/cql/cql_using/paging_c.html

As part of this approach, moved the CQL generation to a new class

Based on the various config that affects the CQL generation, the following precedence for CQL generation modes is currently implemented:
- bulk
- INCREMENTALMODE in KCQL
- config

All existing capabilities should work even with this incomplete feature. 
There are two areas still in progress
- need to refactor `CassandraTableReader` offset so relies on `CqlGenerator` to determine type (date vs token)
- need to refactor `CassandraTableReader` to use tokenDefaultStatement vs tokenStatementWithOffset

UPDATE
- originally was using KCQL 1.0.1 but upgraded to 1.0.3 
