### PR TITLE
JMSSource Default Options

### DIFF
--- a/kafka-connect-jms/src/main/java/com/datamountaineer/streamreactor/connect/converters/ByteArrayConverter.java
+++ b/kafka-connect-jms/src/main/java/com/datamountaineer/streamreactor/connect/converters/ByteArrayConverter.java
@@ -1,0 +1,37 @@
+package com.datamountaineer.streamreactor.connect.converters;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.storage.Converter;
+ 
+import java.util.Map;
+ 
+/**
+ * Pass-through converter for raw byte data.
+ */
+public class ByteArrayConverter implements Converter {
+ 
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+ 
+    @Override
+    public byte[] fromConnectData(String topic, Schema schema, Object value) {
+        if (schema != null && schema.type() != Schema.Type.BYTES && !schema.equals(Schema.OPTIONAL_BYTES_SCHEMA)) {
+            throw new DataException("Invalid schema type for ByteArrayConverter: " + schema.type().toString());
+        }
+
+        if (value != null && !(value instanceof byte[])) {
+            throw new DataException("ByteArrayConverter is not compatible with objects of type " + value.getClass());
+        }
+ 
+        return (byte[]) value;
+    }
+ 
+    @Override
+    public SchemaAndValue toConnectData(String topic, byte[] value) {
+        return new SchemaAndValue(Schema.OPTIONAL_BYTES_SCHEMA, value);
+    }
+ 
+}

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
@@ -28,7 +28,7 @@ object JMSConfig {
       "Connection", 1, ConfigDef.Width.MEDIUM, JMSConfigConstants.JMS_URL)
     .define(JMSConfigConstants.INITIAL_CONTEXT_FACTORY, Type.STRING, Importance.HIGH, JMSConfigConstants.INITIAL_CONTEXT_FACTORY_DOC,
       "Connection", 2, ConfigDef.Width.MEDIUM, JMSConfigConstants.INITIAL_CONTEXT_FACTORY)
-    .define(JMSConfigConstants.CONNECTION_FACTORY, Type.STRING, Importance.HIGH, JMSConfigConstants.CONNECTION_FACTORY_DOC,
+    .define(JMSConfigConstants.CONNECTION_FACTORY, Type.STRING, JMSConfigConstants.CONNECTION_FACTORY_DEFAULT, Importance.HIGH, JMSConfigConstants.CONNECTION_FACTORY_DOC,
       "Connection", 3, ConfigDef.Width.MEDIUM, JMSConfigConstants.CONNECTION_FACTORY)
     .define(JMSConfigConstants.KCQL, Type.STRING, Importance.HIGH, JMSConfigConstants.KCQL,
       "Connection", 4, ConfigDef.Width.MEDIUM, JMSConfigConstants.KCQL)
@@ -61,7 +61,9 @@ object JMSConfig {
 
     //converters
     .define(JMSConfigConstants.CONVERTER_CONFIG, Type.STRING, "", Importance.HIGH, JMSConfigConstants.CONVERTER_DOC,
-    "Converter", 1, ConfigDef.Width.MEDIUM, JMSConfigConstants.CONVERTER_DISPLAY)
+      "Converter", 1, ConfigDef.Width.MEDIUM, JMSConfigConstants.CONVERTER_DISPLAY)
+    .define(JMSConfigConstants.DEFAULT_CONVERTER_CONFIG, Type.STRING, "", Importance.HIGH, JMSConfigConstants.DEFAULT_CONVERTER_DOC,
+      "Converter", 1, ConfigDef.Width.MEDIUM, JMSConfigConstants.DEFAULT_CONVERTER_DISPLAY)
     .define(JMSConfigConstants.THROW_ON_CONVERT_ERRORS_CONFIG, Type.BOOLEAN, JMSConfigConstants.THROW_ON_CONVERT_ERRORS_DEFAULT,
       Importance.HIGH, JMSConfigConstants.THROW_ON_CONVERT_ERRORS_DOC, "Converter", 2, ConfigDef.Width.MEDIUM,
       JMSConfigConstants.THROW_ON_CONVERT_ERRORS_DISPLAY)

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
@@ -32,6 +32,8 @@ object JMSConfigConstants {
   val CONNECTION_FACTORY = "connect.jms.connection.factory"
   private[config] val CONNECTION_FACTORY_DOC = "Provides the full class name for the ConnectionFactory implementation to use, e.g" +
     "org.apache.activemq.ActiveMQConnectionFactory"
+  val CONNECTION_FACTORY_DEFAULT = "ConnectionFactory"
+
 
   val KCQL = "connect.jms.kcql"
   val KCQL_DOC =  "KCQL expression describing field selection and routes."
@@ -60,6 +62,16 @@ object JMSConfigConstants {
       |If the source topic is not matched it will default to the BytesConverter
       |i.e. $jms_source1=com.datamountaineer.streamreactor.connect.source.converters.AvroConverter;$jms_source2=com.datamountaineer.streamreactor.connect.source.converters.JsonConverter""".stripMargin
   private[config] val CONVERTER_DISPLAY = "Converter class"
+
+
+  val DEFAULT_CONVERTER_CONFIG = "connect.jms.source.default.converter"
+  private[config] val DEFAULT_CONVERTER_DOC =
+    """
+      |Contains a canonical class name for the default converter of a raw JMS message bytes to a SourceRecord.
+      |Overides to the default can be done by using connect.jms.source.converters still.
+      |i.e. com.datamountaineer.streamreactor.connect.source.converters.AvroConverter""".stripMargin
+  private[config] val DEFAULT_CONVERTER_DISPLAY = "Default Converter class"
+
 
   val THROW_ON_CONVERT_ERRORS_CONFIG = "connect.jms.converter.throw.on.error"
   private[config] val THROW_ON_CONVERT_ERRORS_DOC = "If set to false the conversion exception will be swallowed and everything carries on BUT the message is lost!!; true will throw the exception.Default is false."


### PR DESCRIPTION
Added ConnectionFactory default
Add config to provide a default converter
Add byte array connect converter which handles optional to allow straight byte passthrough, set using value.converter.