### PR TITLE
ISSUE 179 : Support Shared Durable Subscription on JMS 2.0 Topics

### DIFF
--- a/kafka-connect-jms/build.gradle
+++ b/kafka-connect-jms/build.gradle
@@ -17,13 +17,13 @@
 project(":kafka-connect-jms") {
 
     ext {
-        jmsVersion = "1.1-rev-1"
+        jmsVersion = "2.0.1"
         scalaxVersion = "1.26.0"
     }
 
     dependencies {
-        compile("javax.jms:jms-api:$jmsVersion")
         compile("org.apache.activemq:activemq-core:5.7.0")
+        compile("javax.jms:javax.jms-api:$jmsVersion")
         testCompile("org.json4s:json4s-native_$scalaMajorVersion:$json4sVersion")
         testCompile("com.sksamuel.avro4s:avro4s-core_$scalaMajorVersion:$avro4sVersion")
         testCompile("com.sksamuel.avro4s:avro4s-macros_$scalaMajorVersion:$avro4sVersion")

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfig.scala
@@ -36,6 +36,8 @@ object JMSConfig {
       "Connection", 5, ConfigDef.Width.MEDIUM, JMSConfigConstants.QUEUE_LIST)
     .define(JMSConfigConstants.TOPIC_LIST, Type.LIST, new util.ArrayList[String], Importance.HIGH, JMSConfigConstants.TOPIC_LIST_DOC,
       "Connection", 6, ConfigDef.Width.MEDIUM, JMSConfigConstants.TOPIC_LIST)
+    .define(JMSConfigConstants.TOPIC_SUBSCRIPTION_NAME, Type.STRING, null, Importance.HIGH, JMSConfigConstants.TOPIC_SUBSCRIPTION_NAME_DOC,
+      "Connection", 6, ConfigDef.Width.MEDIUM, JMSConfigConstants.TOPIC_SUBSCRIPTION_NAME)
     .define(JMSConfigConstants.JMS_PASSWORD, Type.PASSWORD, null, Importance.HIGH, JMSConfigConstants.JMS_PASSWORD_DOC,
       "Connection", 7, ConfigDef.Width.MEDIUM, JMSConfigConstants.JMS_PASSWORD)
     .define(JMSConfigConstants.JMS_USER, Type.STRING, null, Importance.HIGH, JMSConfigConstants.JMS_USER_DOC,

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSConfigConstants.scala
@@ -85,6 +85,9 @@ object JMSConfigConstants {
   val TOPIC_LIST = "connect.jms.topics"
   val TOPIC_LIST_DOC = "A comma separated list of JMS topics, must match the KCQL source or target JMS topics."
 
+  val TOPIC_SUBSCRIPTION_NAME = "connect.jms.subscription.name"
+  val TOPIC_SUBSCRIPTION_NAME_DOC = "subscription name to use when subscribing to a topic, specifying this makes a durable subscription for topics"
+
   val QUEUE_LIST = "connect.jms.queues"
   val QUEUE_LIST_DOC = "A comma separated list of JMS topics, must match the KCQL source or target JMS queues."
 

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSSettings.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSSettings.scala
@@ -33,6 +33,7 @@ case class JMSSettings(connectionURL: String,
                        destinationSelector: DestinationSelector,
                        extraProps : List[Map[String, String]],
                        settings: List[JMSSetting],
+                       subscriptionName: Option[String],
                        user: Option[String],
                        password: Option[Password],
                        batchSize: Int,
@@ -137,6 +138,7 @@ object JMSSettings extends StrictLogging {
     }
 
     val jmsTopics = config.getList(JMSConfigConstants.TOPIC_LIST).toSet
+    val jmsSubscriptionName = config.getString(JMSConfigConstants.TOPIC_SUBSCRIPTION_NAME);
     val jmsQueues = config.getList(JMSConfigConstants.QUEUE_LIST).toSet
 
     val settings = kcql.map(r => {
@@ -155,6 +157,7 @@ object JMSSettings extends StrictLogging {
       destinationSelector,
       extraProps,
       settings,
+      Option(jmsSubscriptionName),
       Option(user),
       Option(passwordRaw),
       batchSize,


### PR DESCRIPTION
Add configuration to provide subscription name
Bump JMS API to 2.0
Add logic to create a shared durable subscriber if destination is Topic and subscription name exists.