### PR TITLE
Add Test with KCQL Batch 

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -47,7 +47,8 @@ case class CassandraSourceSetting(routes: Config,
                                   pollInterval: Long = CassandraConfigConstants.DEFAULT_POLL_INTERVAL,
                                   consistencyLevel: Option[ConsistencyLevel],
                                   errorPolicy: ErrorPolicy = new ThrowErrorPolicy,
-                                  taskRetires: Int = CassandraConfigConstants.NBR_OF_RETIRES_DEFAULT
+                                  taskRetires: Int = CassandraConfigConstants.NBR_OF_RETIRES_DEFAULT,
+                                  fetchSize: Int = CassandraConfigConstants.FETCH_SIZE_DEFAULT
                                  ) extends CassandraSetting
 
 case class CassandraSinkSetting(keySpace: String,
@@ -84,6 +85,7 @@ object CassandraSettings extends StrictLogging {
     val errorPolicy = config.getErrorPolicy
     val routes = config.getRoutes
     val primaryKeyCols = routes.map(r => (r.getSource, r.getPrimaryKeys.toList)).toMap
+    val fetchSize = config.getInt(CassandraConfigConstants.FETCH_SIZE)
 
     routes.map({
       r => {
@@ -101,7 +103,8 @@ object CassandraSettings extends StrictLogging {
           bulkImportMode = bulk,
           pollInterval = pollInterval,
           errorPolicy = errorPolicy,
-          consistencyLevel = consistencyLevel
+          consistencyLevel = consistencyLevel,
+          fetchSize = fetchSize
         )
       }
     })

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -135,7 +135,7 @@ class CassandraTableReader(private val session: Session,
     val formattedPrevious = dateFormatter.format(previous)
     val formattedNow = dateFormatter.format(now)
     val bound = preparedStatement.bind(previous, now)
-    logger.info(s"Query ${preparedStatement.getQueryString} executing with bindings ($formattedPrevious, $formattedNow).")
+    logger.debug(s"Query ${preparedStatement.getQueryString} executing with bindings ($formattedPrevious, $formattedNow).")
     session.executeAsync(bound)
   }
 
@@ -148,7 +148,7 @@ class CassandraTableReader(private val session: Session,
     //bind the offset and db time
     val bound = preparedStatement.bind()
     //execute the query
-    logger.info(s"Query ${preparedStatement.getQueryString} executing.")
+    logger.debug(s"Query ${preparedStatement.getQueryString} executing.")
     session.executeAsync(bound)
   }
 
@@ -179,7 +179,7 @@ class CassandraTableReader(private val session: Session,
               } else {
                 getTimebasedMaxOffsetForRow(maxOffset, row)
               }
-              logger.info(s"Max Offset is currently: ${maxOffset.get}")
+              logger.debug(s"Max Offset is currently: ${maxOffset.get}")
             }
             processRow(row)
             counter += 1
@@ -296,7 +296,7 @@ class CassandraTableReader(private val session: Session,
     val table = config.getTarget
     stop.set(true)
     while (querying.get()) {
-      logger.info(s"Waiting for querying to stop for $keySpace.$table.")
+      logger.debug(s"Waiting for querying to stop for $keySpace.$table.")
       Thread.sleep(2000)
     }
     logger.info(s"Querying stopped for $keySpace.$table.")

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -23,7 +23,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
   private val keySpace = setting.keySpace
   private val selectColumns = getSelectColumns
   private val incrementMode = determineMode
-  private val limitRowsSize = config.getBatchSize
+  private val limitRowsSize = setting.fetchSize
 
   private val defaultTimestamp = "1900-01-01 00:00:00.0000000Z"
 
@@ -75,7 +75,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
     val fieldList = config.getFieldAlias.map(fa => fa.getField).toList
     // if no columns set then select all the columns in the table
     val selectColumns = if (fieldList == null || fieldList.isEmpty) "*" else fieldList.mkString(",")
-    logger.info(s"the fields to select are $selectColumns")
+    logger.debug(s"the fields to select are $selectColumns")
     selectColumns
   }
 

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -23,7 +23,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
   private val keySpace = setting.keySpace
   private val selectColumns = getSelectColumns
   private val incrementMode = determineMode
-  private val limitRowsSize = setting.fetchSize
+  private val limitRowsSize = config.getBatchSize
 
   private val defaultTimestamp = "1900-01-01 00:00:00.0000000Z"
 

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -61,7 +61,7 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
     val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=token", "timeuuid"))
     val cqlStatement = cqlGenerator.getCqlStatement
 
-    cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE token(timestamp_field) > token(?) LIMIT 3000"
+    cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE token(timestamp_field) > token(?) LIMIT 200"
   }
 
   "Exception should be thrown with unknown incremental mode in KCQL" in {
@@ -95,7 +95,7 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE3",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000",
-        CassandraConfigConstants.BATCH_SIZE -> "200",
+        CassandraConfigConstants.FETCH_SIZE -> "200",
         CassandraConfigConstants.TIMESTAMP_TYPE -> configIncrementMode).asJava
     }
     val configSource = new CassandraConfigSource(configMap)

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -87,7 +87,7 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
   }
 
   def configureMe(kcqlIncrementMode: String, configIncrementMode: String): CassandraSourceSetting = {
-    val myKcql = s"INSERT INTO kafka-topic SELECT string_field, timestamp_field FROM cassandra-table PK timestamp_field $kcqlIncrementMode"
+    val myKcql = s"INSERT INTO kafka-topic SELECT string_field, timestamp_field FROM cassandra-table PK timestamp_field BATCH=200 $kcqlIncrementMode"
     val configMap = {
       Map(
         CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
@@ -95,7 +95,8 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE3",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000",
-        CassandraConfigConstants.FETCH_SIZE -> "200",
+        CassandraConfigConstants.FETCH_SIZE -> "500",
+        CassandraConfigConstants.BATCH_SIZE -> "800",
         CassandraConfigConstants.TIMESTAMP_TYPE -> configIncrementMode).asJava
     }
     val configSource = new CassandraConfigSource(configMap)


### PR DESCRIPTION
This PR is an attempt to correct #190 
It reverts the `CqlGenerator` to using the BATCH in KCQL instead of fetch.size in the config
It adds a test to show that it is working correctly w/ CQL that uses the token/paging

The `connect.cassandra.fetch.size` was added to `CassandraSettings` since it was not available to the Cassandra Source connector before. However it is currently not used in the `CqlGenerator`.