### PR TITLE
Cassandra Source: Token/page based CQL 

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -47,7 +47,8 @@ case class CassandraSourceSetting(routes: Config,
                                   pollInterval: Long = CassandraConfigConstants.DEFAULT_POLL_INTERVAL,
                                   consistencyLevel: Option[ConsistencyLevel],
                                   errorPolicy: ErrorPolicy = new ThrowErrorPolicy,
-                                  taskRetires: Int = CassandraConfigConstants.NBR_OF_RETIRES_DEFAULT
+                                  taskRetires: Int = CassandraConfigConstants.NBR_OF_RETIRES_DEFAULT,
+                                  fetchSize: Int = CassandraConfigConstants.FETCH_SIZE_DEFAULT
                                  ) extends CassandraSetting
 
 case class CassandraSinkSetting(keySpace: String,
@@ -84,6 +85,7 @@ object CassandraSettings extends StrictLogging {
     val errorPolicy = config.getErrorPolicy
     val routes = config.getRoutes
     val primaryKeyCols = routes.map(r => (r.getSource, r.getPrimaryKeys.toList)).toMap
+    val fetchSize = config.getInt(CassandraConfigConstants.FETCH_SIZE)
 
     routes.map({
       r => {
@@ -101,7 +103,8 @@ object CassandraSettings extends StrictLogging {
           bulkImportMode = bulk,
           pollInterval = pollInterval,
           errorPolicy = errorPolicy,
-          consistencyLevel = consistencyLevel
+          consistencyLevel = consistencyLevel,
+          fetchSize = fetchSize
         )
       }
     })

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -135,7 +135,7 @@ class CassandraTableReader(private val session: Session,
     val formattedPrevious = dateFormatter.format(previous)
     val formattedNow = dateFormatter.format(now)
     val bound = preparedStatement.bind(previous, now)
-    logger.info(s"Query ${preparedStatement.getQueryString} executing with bindings ($formattedPrevious, $formattedNow).")
+    logger.debug(s"Query ${preparedStatement.getQueryString} executing with bindings ($formattedPrevious, $formattedNow).")
     session.executeAsync(bound)
   }
 
@@ -148,7 +148,7 @@ class CassandraTableReader(private val session: Session,
     //bind the offset and db time
     val bound = preparedStatement.bind()
     //execute the query
-    logger.info(s"Query ${preparedStatement.getQueryString} executing.")
+    logger.debug(s"Query ${preparedStatement.getQueryString} executing.")
     session.executeAsync(bound)
   }
 
@@ -179,7 +179,7 @@ class CassandraTableReader(private val session: Session,
               } else {
                 getTimebasedMaxOffsetForRow(maxOffset, row)
               }
-              logger.info(s"Max Offset is currently: ${maxOffset.get}")
+              logger.debug(s"Max Offset is currently: ${maxOffset.get}")
             }
             processRow(row)
             counter += 1
@@ -296,7 +296,7 @@ class CassandraTableReader(private val session: Session,
     val table = config.getTarget
     stop.set(true)
     while (querying.get()) {
-      logger.info(s"Waiting for querying to stop for $keySpace.$table.")
+      logger.debug(s"Waiting for querying to stop for $keySpace.$table.")
       Thread.sleep(2000)
     }
     logger.info(s"Querying stopped for $keySpace.$table.")

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -19,9 +19,9 @@ package com.datamountaineer.streamreactor.connect.cassandra.source
 import java.text.SimpleDateFormat
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.{Collections, Date}
+import java.util.{ Collections, Date }
 
-import com.datamountaineer.streamreactor.connect.cassandra.config.{CassandraConfigConstants, CassandraSourceSetting, TimestampType}
+import com.datamountaineer.streamreactor.connect.cassandra.config.{ CassandraConfigConstants, CassandraSourceSetting, TimestampType }
 import com.datamountaineer.streamreactor.connect.cassandra.utils.CassandraResultSetWrapper.resultSetFutureToScala
 import com.datamountaineer.streamreactor.connect.cassandra.utils.CassandraUtils
 import com.datamountaineer.streamreactor.connect.offsets.OffsetHandler
@@ -29,29 +29,28 @@ import com.datastax.driver.core._
 import com.datastax.driver.core.utils.UUIDs
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.kafka.connect.errors.ConnectException
-import org.apache.kafka.connect.source.{SourceRecord, SourceTaskContext}
+import org.apache.kafka.connect.source.{ SourceRecord, SourceTaskContext }
 
 import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.connect.data.Schema
 
 /**
-  * Created by andrew@datamountaineer.com on 20/04/16.
-  * stream-reactor
-  */
+ * Created by andrew@datamountaineer.com on 20/04/16.
+ * stream-reactor
+ */
 class CassandraTableReader(private val session: Session,
-                           private val setting: CassandraSourceSetting,
-                           private val context: SourceTaskContext,
-                           var queue: LinkedBlockingQueue[SourceRecord]) extends StrictLogging {
-
+    private val setting: CassandraSourceSetting,
+    private val context: SourceTaskContext,
+    var queue: LinkedBlockingQueue[SourceRecord]) extends StrictLogging {
 
   private val config = setting.routes
   private val cqlGenerator = new CqlGenerator(setting)
-  
+
   private val dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS'Z'")
   private val primaryKeyCol = setting.primaryKeyColumn.getOrElse("")
   private val querying = new AtomicBoolean(false)
@@ -65,13 +64,12 @@ class CassandraTableReader(private val session: Session,
   private val sourcePartition = Collections.singletonMap(CassandraConfigConstants.ASSIGNED_TABLES, table)
   private val schemaName = s"$keySpace.$table".replace('-', '.')
 
-
   /**
-    * Build a map of table to offset.
-    *
-    * @param context SourceTaskContext for this task.
-    * @return The last stored offset.
-    */
+   * Build a map of table to offset.
+   *
+   * @param context SourceTaskContext for this task.
+   * @return The last stored offset.
+   */
   private def buildOffsetMap(context: SourceTaskContext): Option[String] = {
     val offsetStorageKey = CassandraConfigConstants.ASSIGNED_TABLES
     val tables = List(table)
@@ -82,17 +80,17 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Build a preparedStatement for the given table.
-    *
-    * @return the PreparedStatement
-    */
+   * Build a preparedStatement for the given table.
+   *
+   * @return the PreparedStatement
+   */
   private def getPreparedStatements: PreparedStatement = {
     val selectStatement = cqlGenerator.getCqlStatement
     val statement = session.prepare(selectStatement)
     setting.consistencyLevel.foreach(statement.setConsistencyLevel)
     statement
   }
-  
+
   private def getPreparedStatementNoOffset: PreparedStatement = {
     val selectStatement = cqlGenerator.getCqlStatementNoOffset
     val statement = session.prepare(selectStatement)
@@ -101,9 +99,9 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Fires Cassandra queries and increments the timestamp
-    * Every Row returned from query is put into the queue for processing.
-    */
+   * Fires Cassandra queries and increments the timestamp
+   * Every Row returned from query is put into the queue for processing.
+   */
   def read(): Unit = if (!stop.get() && !querying.get()) query()
 
   private def query() = {
@@ -112,19 +110,19 @@ class CassandraTableReader(private val session: Session,
 
     // execute the query, gives us back a future result set
     val frs = if (setting.bulkImportMode) {
+      // bulk
       resultSetFutureToScala(fireQuery(preparedStatement))
     } else if (cqlGenerator.isTokenBased()) {
       // token based 
       tableOffset match {
-        case Some(tableOffset) => resultSetFutureToScala(bindAndFireQuery(tableOffset))
+        // use offset/token to page thru results
+        case Some(tableOffset) => resultSetFutureToScala(bindAndFireTokenQuery(tableOffset))
+        // no offset so just read first set of rows
         case None => resultSetFutureToScala(fireQuery(preparedStatementNoOffset))
       }
     } else {
-      // time based key column
-      val lowerBound = dateFormatter.parse(cqlGenerator.getDefaultOffsetValue(tableOffset).get)
-      // set the upper bound to now
-      val upperBound = new Date()
-      resultSetFutureToScala(bindAndFireQuery(lowerBound, upperBound))
+      // time based
+      resultSetFutureToScala(bindAndFireTimebasedQuery())
     }
 
     //give futureresultset to the process method to extract records,
@@ -133,13 +131,17 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Bind and execute the preparedStatement and set querying to true.
-    *
-    * @param previous The previous timestamp to bind.
-    * @param now      The current timestamp on the db to bind.
-    * @return a ResultSet.
-    */
-  private def bindAndFireQuery(previous: Date, now: Date) = {
+   * Bind and execute the preparedStatement and set querying to true.
+   *
+   * @param previous The previous timestamp to bind.
+   * @param now      The current timestamp on the db to bind.
+   * @return a ResultSet.
+   */
+  private def bindAndFireTimebasedQuery() = {
+    // time based key column
+    val previous = dateFormatter.parse(cqlGenerator.getDefaultOffsetValue(tableOffset).get)
+    // set the upper bound to now
+    val now = new Date()
     //bind the offset and db time
     val formattedPrevious = dateFormatter.format(previous)
     val formattedNow = dateFormatter.format(now)
@@ -147,24 +149,24 @@ class CassandraTableReader(private val session: Session,
     logger.debug(s"Query ${preparedStatement.getQueryString} executing with bindings ($formattedPrevious, $formattedNow).")
     session.executeAsync(bound)
   }
-  
-    /**
-    * Bind and execute the preparedStatement and set querying to true.
-    *
-    * @param lastToken The last token from previous query
-    * @return a ResultSet.
-    */
-  private def bindAndFireQuery(lastToken: String) = {
-    val bound = preparedStatement.bind(lastToken)
+
+  /**
+   * Bind and execute the preparedStatement and set querying to true.
+   *
+   * @param lastToken The last token from previous query
+   * @return a ResultSet.
+   */
+  private def bindAndFireTokenQuery(lastToken: String) = {
+    val bound = preparedStatement.bind(java.util.UUID.fromString(lastToken))
     logger.debug(s"Query ${preparedStatement.getQueryString} executing with bindings ($lastToken).")
     session.executeAsync(bound)
   }
 
   /**
-    * Execute the preparedStatement and set querying to true.
-    *
-    * @return a ResultSet.
-    */
+   * Execute the preparedStatement and set querying to true.
+   *
+   * @return a ResultSet.
+   */
   private def fireQuery(ps: PreparedStatement): ResultSetFuture = {
     //bind the offset and db time
     val bound = ps.bind()
@@ -174,11 +176,11 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Iterate over the resultset, extract SourceRecords
-    * and add them to the queue.
-    *
-    * @param future Cassandra Future ResultSet to iterate over.
-    */
+   * Iterate over the resultset, extract SourceRecords
+   * and add them to the queue.
+   *
+   * @param future Cassandra Future ResultSet to iterate over.
+   */
   private def process(future: Future[ResultSet]) = {
     //get the max offset per query
     var maxOffset: Option[String] = None
@@ -223,23 +225,23 @@ class CassandraTableReader(private val session: Session,
         throw new ConnectException(s"Error will querying $table.", t)
     })
   }
-  
+
   private def getTokenMaxOffsetForRow(maxOffset: Option[String], row: Row): Option[String] = {
-    //TODO
-    null
+    val rowOffsetUuid = extractUuid(row)
+    if (rowOffsetUuid.isEmpty) maxOffset else rowOffsetUuid
   }
-  
+
   private def getTimebasedMaxOffsetForRow(maxOffset: Option[String], row: Row): Option[String] = {
     val rowOffsetDate = extractTimestamp(row)
     if (maxOffset.isEmpty || rowOffsetDate.after(dateFormatter.parse(maxOffset.get))) Some(dateFormatter.format(rowOffsetDate)) else maxOffset
   }
 
   /**
-    * Process a Cassandra row, convert it to a SourceRecord and put in queue
-    *
-    * @param row The Cassandra row to process.
-    *
-    */
+   * Process a Cassandra row, convert it to a SourceRecord and put in queue
+   *
+   * @param row The Cassandra row to process.
+   *
+   */
   private def processRow(row: Row) = {
     // convert the cassandra row to a struct
     val ignoreList = config.getIgnoredField.toList
@@ -248,13 +250,12 @@ class CassandraTableReader(private val session: Session,
 
     // get the offset for this value
     val offset: String = if (cqlGenerator.isTokenBased()) {
-      // token
-      null
+      extractUuid(row).getOrElse("")
     } else {
       val rowOffset: Date = if (setting.bulkImportMode) dateFormatter.parse(tableOffset.get) else extractTimestamp(row)
       dateFormatter.format(rowOffset)
     }
-    
+
     logger.debug(s"Storing offset $offset")
 
     // create source record
@@ -275,11 +276,11 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Extract the CQL UUID timestamp and return a date
-    *
-    * @param row The row to extract the timestamp from
-    * @return A java.util.Date
-    */
+   * Extract the CQL UUID timestamp and return a date
+   *
+   * @param row The row to extract the timestamp from
+   * @return A java.util.Date
+   */
   private def extractTimestamp(row: Row): Date = {
     Try(row.getTimestamp(setting.primaryKeyColumn.get)) match {
       case Success(s) => s
@@ -288,10 +289,23 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Set the offset for the table and set querying to false
-    *
-    * @param offset the date to set the offset to
-    */
+   * extract the CQL primary key (expected to be UUID)
+   *
+   * @param row The row to extract the UUID
+   * @return an Option[String]
+   */
+  private def extractUuid(row: Row): Option[String] = {
+    Try(row.getUUID(setting.primaryKeyColumn.get)) match {
+      case Success(s) => Some(s.toString())
+      case Failure(_) => None
+    }
+  }
+
+  /**
+   * Set the offset for the table and set querying to false
+   *
+   * @param offset the date to set the offset to
+   */
   private def reset(offset: Option[String]) = {
     //set the offset to the 'now' bind value
     val table = config.getTarget
@@ -303,8 +317,8 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Closed down the driver session and cluster.
-    */
+   * Closed down the driver session and cluster.
+   */
   def close(): Unit = {
     logger.info("Shutting down Queries.")
     stopQuerying()
@@ -312,8 +326,8 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Tell me to stop processing.
-    */
+   * Tell me to stop processing.
+   */
   def stopQuerying(): Unit = {
     val table = config.getTarget
     stop.set(true)
@@ -325,8 +339,8 @@ class CassandraTableReader(private val session: Session,
   }
 
   /**
-    * Is the reader in the middle of a query
-    */
+   * Is the reader in the middle of a query
+   */
   def isQuerying: Boolean = {
     querying.get()
   }
@@ -334,9 +348,9 @@ class CassandraTableReader(private val session: Session,
 
 object CassandraTableReader {
   def apply(session: Session,
-            setting: CassandraSourceSetting,
-            context: SourceTaskContext,
-            queue: LinkedBlockingQueue[SourceRecord]): CassandraTableReader = {
+    setting: CassandraSourceSetting,
+    context: SourceTaskContext,
+    queue: LinkedBlockingQueue[SourceRecord]): CassandraTableReader = {
     //return a reader
     new CassandraTableReader(session = session,
       setting = setting,

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -44,9 +44,9 @@ import org.apache.kafka.connect.data.Schema
  * stream-reactor
  */
 class CassandraTableReader(private val session: Session,
-    					             private val setting: CassandraSourceSetting,
-                           private val context: SourceTaskContext,
-    					             var queue: LinkedBlockingQueue[SourceRecord]) extends StrictLogging {
+                            private val setting: CassandraSourceSetting,
+                            private val context: SourceTaskContext,
+                            var queue: LinkedBlockingQueue[SourceRecord]) extends StrictLogging {
 
   private val config = setting.routes
   private val cqlGenerator = new CqlGenerator(setting)

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -23,7 +23,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
   private val keySpace = setting.keySpace
   private val selectColumns = getSelectColumns
   private val incrementMode = determineMode
-  private val limitRowsSize = config.getBatchSize
+  private val limitRowsSize = setting.fetchSize
 
   private val defaultTimestamp = "1900-01-01 00:00:00.0000000Z"
 
@@ -75,7 +75,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
     val fieldList = config.getFieldAlias.map(fa => fa.getField).toList
     // if no columns set then select all the columns in the table
     val selectColumns = if (fieldList == null || fieldList.isEmpty) "*" else fieldList.mkString(",")
-    logger.info(s"the fields to select are $selectColumns")
+    logger.debug(s"the fields to select are $selectColumns")
     selectColumns
   }
 

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CqlGenerator.scala
@@ -23,7 +23,7 @@ class CqlGenerator(private val setting: CassandraSourceSetting) extends StrictLo
   private val keySpace = setting.keySpace
   private val selectColumns = getSelectColumns
   private val incrementMode = determineMode
-  private val limitRowsSize = setting.fetchSize
+  private val limitRowsSize = config.getBatchSize
 
   private val defaultTimestamp = "1900-01-01 00:00:00.0000000Z"
 

--- a/kafka-connect-cassandra/src/test/resources/log4j.properties
+++ b/kafka-connect-cassandra/src/test/resources/log4j.properties
@@ -15,7 +15,7 @@
 #
 
 # suppress inspection "UnusedProperty" for whole file
-log4j.rootLogger=INFO,stdout
+log4j.rootLogger=DEBUG,stdout
 
 #stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
@@ -55,7 +55,8 @@ trait TestConfig extends StrictLogging with MockitoSugar {
   val TABLE3 = TOPIC2
   val TABLE4 = "table4"
   val TOPIC4 =  "topic4"
-
+  val TABLE5 = "table5"
+  
   val USERNAME = "cassandra"
   val PASSWD = "cassandra"
   val TRUST_STORE_PATH = System.getProperty("truststore")
@@ -258,7 +259,17 @@ trait TestConfig extends StrictLogging with MockitoSugar {
          |double_field double,
          |timestamp_field timeuuid,
          |PRIMARY KEY(id,timestamp_field)) WITH CLUSTERING ORDER BY (timestamp_field asc)""".stripMargin)
-
+    session.execute(
+      s"""
+          CREATE TABLE IF NOT EXISTS $CASSANDRA_KEYSPACE.$TABLE5 (
+            id text, 
+            int_field int, 
+            long_field bigint,
+            string_field text, 
+            timestamp_field timestamp, 
+            timeuuid_field timeuuid, 
+            PRIMARY KEY ((id), timeuuid_field))""".stripMargin)
+            
     session
   }
 

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
@@ -262,13 +262,12 @@ trait TestConfig extends StrictLogging with MockitoSugar {
     session.execute(
       s"""
           CREATE TABLE IF NOT EXISTS $CASSANDRA_KEYSPACE.$TABLE5 (
-            id text, 
+            id timeuuid, 
             int_field int, 
             long_field bigint,
             string_field text, 
-            timestamp_field timestamp, 
-            timeuuid_field timeuuid, 
-            PRIMARY KEY ((id), timeuuid_field))""".stripMargin)
+            another_time_field timeuuid, 
+            PRIMARY KEY ((id), another_time_field))""".stripMargin)
             
     session
   }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTokenCql.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTokenCql.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Datamountaineer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datamountaineer.streamreactor.connect.cassandra.source
+
+import java.text.SimpleDateFormat
+import java.util.Date
+
+import com.datamountaineer.streamreactor.connect.cassandra.TestConfig
+import com.datamountaineer.streamreactor.connect.cassandra.config.CassandraConfigConstants
+import com.datamountaineer.streamreactor.connect.schemas.ConverterUtil
+import com.fasterxml.jackson.databind.JsonNode
+import org.apache.kafka.common.config.ConfigException
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
+
+import scala.collection.JavaConverters._
+import org.apache.kafka.connect.data.Schema
+
+/**
+ * test incremental mode specifying a subset of table columns
+ * note: the timestamp column is required as part of SELECT
+ */
+class TestCassandraSourceTaskTokenCql extends WordSpec with Matchers with BeforeAndAfter with MockitoSugar with TestConfig
+    with ConverterUtil {
+
+  before {
+    startEmbeddedCassandra()
+  }
+
+  after {
+    stopEmbeddedCassandra()
+  }
+
+  "A Cassandra SourceTask should read records with only columns specified using Token CQL" in {
+    val session = createTableAndKeySpace(secure = true, ssl = false)
+
+    val formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ")
+    val now = new Date()
+    val formatted = formatter.format(now)
+
+    val sql = s"INSERT INTO $CASSANDRA_KEYSPACE.$TABLE5" +
+      "(id, int_field, long_field, string_field, timestamp_field, timeuuid_field) " +
+      s"VALUES ('id1', 2, 3, 'magic_string', '$formatted', now());"
+    session.execute(sql)
+
+    //wait for cassandra write a little
+    Thread.sleep(1000)
+
+    val taskContext = getSourceTaskContextDefault
+    //get config
+    val config = {
+      Map(
+        CassandraConfigConstants.CONTACT_POINTS -> CONTACT_POINT,
+        CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
+        CassandraConfigConstants.USERNAME -> USERNAME,
+        CassandraConfigConstants.PASSWD -> PASSWD,
+        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT id, string_field FROM $TABLE5 PK id INCREMENTALMODE=TOKEN",
+        CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE3",
+        CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
+        CassandraConfigConstants.POLL_INTERVAL -> "1000",
+        CassandraConfigConstants.FETCH_SIZE -> "10",
+        CassandraConfigConstants.TIMESTAMP_TYPE -> "timestamp").asJava
+    }
+
+    //get task
+    val task = new CassandraSourceTask()
+    //initialise the tasks context
+    task.initialize(taskContext)
+    //start task
+    task.start(config)
+
+    //trigger poll to have the readers execute a query and add to the queue
+    task.poll()
+
+    //wait a little for the poll to catch the records
+    while (task.queueSize(TABLE3) == 0) {
+      Thread.sleep(5000)
+    }
+
+    //call poll again to drain the queue
+    val records = task.poll()
+
+    val sourceRecord = records.asScala.head
+    //check a field
+    val json: JsonNode = convertValueToJson(sourceRecord)
+    println(json)
+    json.get("id").equals("id1") shouldBe true
+    json.get("string_field").asText().equals("magic_string") shouldBe true
+    json.get("timestamp_field") shouldBe null
+    json.get("int_field") shouldBe null
+    //stop task
+    task.stop()
+  }
+
+}
+
+

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTokenCql.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskTokenCql.scala
@@ -25,10 +25,12 @@ import com.datamountaineer.streamreactor.connect.schemas.ConverterUtil
 import com.fasterxml.jackson.databind.JsonNode
 import org.apache.kafka.common.config.ConfigException
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
+import org.scalatest.{ BeforeAndAfter, Matchers, WordSpec }
 
 import scala.collection.JavaConverters._
 import org.apache.kafka.connect.data.Schema
+import com.datastax.driver.core.Session
+import org.apache.kafka.connect.source.SourceRecord
 
 /**
  * test incremental mode specifying a subset of table columns
@@ -48,29 +50,21 @@ class TestCassandraSourceTaskTokenCql extends WordSpec with Matchers with Before
   "A Cassandra SourceTask should read records with only columns specified using Token CQL" in {
     val session = createTableAndKeySpace(secure = true, ssl = false)
 
-    val formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ")
-    val now = new Date()
-    val formatted = formatter.format(now)
+    // insert 
+    insert(session, "chewie")
+    insert(session, "yoda")
 
-    val sql = s"INSERT INTO $CASSANDRA_KEYSPACE.$TABLE5" +
-      "(id, int_field, long_field, string_field, timestamp_field, timeuuid_field) " +
-      s"VALUES ('id1', 2, 3, 'magic_string', '$formatted', now());"
-    session.execute(sql)
-
-    //wait for cassandra write a little
-    Thread.sleep(1000)
-
+    // the incrementalmode of token should override the timestamptype config 
     val taskContext = getSourceTaskContextDefault
-    //get config
     val config = {
       Map(
         CassandraConfigConstants.CONTACT_POINTS -> CONTACT_POINT,
         CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
         CassandraConfigConstants.USERNAME -> USERNAME,
         CassandraConfigConstants.PASSWD -> PASSWD,
-        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT id, string_field FROM $TABLE5 PK id INCREMENTALMODE=TOKEN",
-        CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE3",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
+        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT id, string_field FROM $TABLE5 PK id BATCH=1 INCREMENTALMODE=TOKEN",
+        CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE5",
         CassandraConfigConstants.POLL_INTERVAL -> "1000",
         CassandraConfigConstants.FETCH_SIZE -> "10",
         CassandraConfigConstants.TIMESTAMP_TYPE -> "timestamp").asJava
@@ -78,34 +72,74 @@ class TestCassandraSourceTaskTokenCql extends WordSpec with Matchers with Before
 
     //get task
     val task = new CassandraSourceTask()
-    //initialise the tasks context
     task.initialize(taskContext)
-    //start task
     task.start(config)
 
-    //trigger poll to have the readers execute a query and add to the queue
-    task.poll()
+    val records = pollAndWait(task)
 
-    //wait a little for the poll to catch the records
-    while (task.queueSize(TABLE3) == 0) {
-      Thread.sleep(5000)
-    }
-
-    //call poll again to drain the queue
-    val records = task.poll()
-
+    records.size() shouldBe 1
+    
     val sourceRecord = records.asScala.head
-    //check a field
     val json: JsonNode = convertValueToJson(sourceRecord)
-    println(json)
-    json.get("id").equals("id1") shouldBe true
-    json.get("string_field").asText().equals("magic_string") shouldBe true
+    
+    val recordId = json.get("id").asText()
+    recordId.size > 0
+    
+    val stringField = json.get("string_field").asText()
+    stringField.equals("yoda") || stringField.equals("chewie") shouldBe true
     json.get("timestamp_field") shouldBe null
     json.get("int_field") shouldBe null
+    
+    //
+    // call 2nd time
+    //
+    val nextRecords = pollAndWait(task)
+    
+    nextRecords.size() shouldBe 1
+    
+    val nextSourceRecord = nextRecords.asScala.head
+    val nextJson: JsonNode = convertValueToJson(nextSourceRecord)
+    
+    val nextRecordId = nextJson.get("id").asText()
+    nextRecordId.size > 0
+    nextRecordId.equals(recordId) shouldBe false
+    
+    val nextStringField = nextJson.get("string_field").asText()
+    nextStringField.equals("yoda") || nextStringField.equals("chewie") shouldBe true
+    nextStringField.equals(recordId) shouldBe false
+    nextJson.get("timestamp_field") shouldBe null
+    nextJson.get("int_field") shouldBe null
+    
     //stop task
     task.stop()
   }
 
+  private def pollAndWait(task: CassandraSourceTask): java.util.List[SourceRecord] = {
+    // trigger poll to have the readers execute a query and add to the queue
+    task.poll()
+
+    // wait a little for the poll to catch the records
+    while (task.queueSize(TABLE5) == 0) {
+      Thread.sleep(5000)
+    }
+
+    // call poll again to drain the queue
+    val records = task.poll()
+    records
+  }
+  
+  private def insert(session: Session, myValue: String) {
+    val sql = s"""INSERT INTO $CASSANDRA_KEYSPACE.$TABLE5
+      (id, int_field, long_field, string_field, another_time_field) 
+      VALUES 
+      (now(), 2, 3, '$myValue', now());"""
+
+    // insert
+    session.execute(sql)
+
+    // wait for Cassandra write
+    Thread.sleep(1000)
+  }
 }
 
 

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -56,12 +56,20 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
     cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE timestamp_field > ? AND timestamp_field <= ? ALLOW FILTERING"
   }
 
-  "CqlGenerator should generate token statement based on KCQL" in {
+  "CqlGenerator should generate token based CQL statement based on KCQL" in {
 
     val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=token", "timeuuid"))
     val cqlStatement = cqlGenerator.getCqlStatement
 
     cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE token(timestamp_field) > token(?) LIMIT 200"
+  }
+  
+  "CqlGenerator should generate CQL statement with no offset based on KCQL" in {
+
+    val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=token", "timeuuid"))
+    val cqlStatement = cqlGenerator.getCqlStatementNoOffset
+
+    cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table LIMIT 200"
   }
 
   "Exception should be thrown with unknown incremental mode in KCQL" in {

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -61,7 +61,7 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
     val cqlGenerator = new CqlGenerator(configureMe("INCREMENTALMODE=token", "timeuuid"))
     val cqlStatement = cqlGenerator.getCqlStatement
 
-    cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE token(timestamp_field) > token(?) LIMIT 3000"
+    cqlStatement shouldBe "SELECT timestamp_field,string_field FROM sink_test.cassandra-table WHERE token(timestamp_field) > token(?) LIMIT 200"
   }
 
   "Exception should be thrown with unknown incremental mode in KCQL" in {
@@ -95,7 +95,7 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE3",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000",
-        CassandraConfigConstants.BATCH_SIZE -> "200",
+        CassandraConfigConstants.FETCH_SIZE -> "200",
         CassandraConfigConstants.TIMESTAMP_TYPE -> configIncrementMode).asJava
     }
     val configSource = new CassandraConfigSource(configMap)

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCqlGenerator.scala
@@ -87,7 +87,7 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
   }
 
   def configureMe(kcqlIncrementMode: String, configIncrementMode: String): CassandraSourceSetting = {
-    val myKcql = s"INSERT INTO kafka-topic SELECT string_field, timestamp_field FROM cassandra-table PK timestamp_field $kcqlIncrementMode"
+    val myKcql = s"INSERT INTO kafka-topic SELECT string_field, timestamp_field FROM cassandra-table PK timestamp_field BATCH=200 $kcqlIncrementMode"
     val configMap = {
       Map(
         CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
@@ -95,7 +95,8 @@ class TestCqlGenerator extends WordSpec with Matchers with BeforeAndAfter with M
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE3",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000",
-        CassandraConfigConstants.FETCH_SIZE -> "200",
+        CassandraConfigConstants.FETCH_SIZE -> "500",
+        CassandraConfigConstants.BATCH_SIZE -> "800",
         CassandraConfigConstants.TIMESTAMP_TYPE -> configIncrementMode).asJava
     }
     val configSource = new CassandraConfigSource(configMap)


### PR DESCRIPTION
This PR builds on #176 and #188
It allows users to configure a Cassandra Source via KCQL to pull data from Cassandra from a table with a partition key that is a UUID. It will then page through additions to the table using token(id)/paging technique as described here

http://docs.datastax.com/en/cql/3.1/cql/cql_using/paging_c.html

Sample KCQL
```INSERT INTO myTopic 
SELECT id, string_field FROM myTable 
PK id 
BATCH=100
INCREMENTALMODE=TOKEN

