### PR TITLE
Fixed Avro double fields mapping to Kudu columns

### DIFF
--- a/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/KuduConverter.scala
+++ b/kafka-connect-kudu/src/main/scala/com/datamountaineer/streamreactor/connect/kudu/KuduConverter.scala
@@ -68,7 +68,7 @@ trait KuduConverter {
       case Type.INT64 => row.addLong(fieldName, struct.getInt64(fieldName))
       case Type.BOOLEAN => row.addBoolean(fieldName, struct.get(fieldName).asInstanceOf[Boolean])
       case Type.FLOAT32 => row.addFloat(fieldName, struct.getFloat32(fieldName))
-      case Type.FLOAT64 => row.addFloat(fieldName, struct.getFloat64(fieldName).toFloat)
+      case Type.FLOAT64 => row.addDouble(fieldName, struct.getFloat64(fieldName))
       case Type.BYTES => row.addBinary(fieldName, struct.getBytes(fieldName))
       case _ => throw new UnsupportedOperationException(s"Unknown type $fieldType")
     }
@@ -110,7 +110,8 @@ trait KuduConverter {
       case Type.INT32 => new ColumnSchemaBuilder(fieldName, org.kududb.Type.INT32)
       case Type.INT64 => new ColumnSchemaBuilder(fieldName, org.kududb.Type.INT64)
       case Type.BOOLEAN => new ColumnSchemaBuilder(fieldName, org.kududb.Type.BOOL)
-      case Type.FLOAT32 | Type.FLOAT64 => new ColumnSchemaBuilder(fieldName, org.kududb.Type.FLOAT)
+      case Type.FLOAT32 => new ColumnSchemaBuilder(fieldName, org.kududb.Type.FLOAT)
+      case Type.FLOAT64 => new ColumnSchemaBuilder(fieldName, org.kududb.Type.DOUBLE)
       case Type.BYTES => new ColumnSchemaBuilder(fieldName, org.kududb.Type.BINARY)
       case _ => throw new UnsupportedOperationException(s"Unknown type $fieldType")
     }
@@ -141,7 +142,7 @@ trait KuduConverter {
       case org.apache.avro.Schema.Type.INT => new ColumnSchema.ColumnSchemaBuilder(fieldName, org.kududb.Type.INT32)
       case org.apache.avro.Schema.Type.LONG => new ColumnSchema.ColumnSchemaBuilder(fieldName, org.kududb.Type.INT64)
       case org.apache.avro.Schema.Type.FLOAT => new ColumnSchema.ColumnSchemaBuilder(fieldName, org.kududb.Type.FLOAT)
-      case org.apache.avro.Schema.Type.DOUBLE => new ColumnSchema.ColumnSchemaBuilder(fieldName, org.kududb.Type.FLOAT)
+      case org.apache.avro.Schema.Type.DOUBLE => new ColumnSchema.ColumnSchemaBuilder(fieldName, org.kududb.Type.DOUBLE)
       case org.apache.avro.Schema.Type.BOOLEAN => new ColumnSchema.ColumnSchemaBuilder(fieldName, org.kududb.Type.BOOL)
       case org.apache.avro.Schema.Type.NULL => throw new RuntimeException("Avro type NULL not supported")
       case _ => throw new RuntimeException("Avro type not supported")

--- a/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduConverter.scala
+++ b/kafka-connect-kudu/src/test/scala/com/datamountaineer/streamreactor/connect/kudu/TestKuduConverter.scala
@@ -102,7 +102,7 @@ class TestKuduConverter extends TestBase with KuduConverter with ConverterUtil w
     kuduFields(2).getName shouldBe "boolean_field"
     kuduFields(2).getType shouldBe org.kududb.Type.BOOL
     kuduFields(3).getName shouldBe "double_field"
-    kuduFields(3).getType shouldBe org.kududb.Type.FLOAT
+    kuduFields(3).getType shouldBe org.kududb.Type.DOUBLE
     kuduFields(4).getName shouldBe "float_field"
     kuduFields(4).getType shouldBe org.kududb.Type.FLOAT
     kuduFields(5).getName shouldBe "long_field"


### PR DESCRIPTION
Fix for Issue #205: DOUBLE fields from Avro schema are mapped to FLOAT in Kudu

Mapped Avro Double fields to Kudu Double columns.