### PR TITLE
Typo in mongodb-sink.properties KCQL parameter leads to BadRequest exception

### DIFF
--- a/conf/mongodb-sink.properties
+++ b/conf/mongodb-sink.properties
@@ -21,3 +21,4 @@ topics=orders-topic
 connect.mongo.sink.kcql=INSERT INTO orders SELECT * FROM orders-topic
 connect.mongo.database=connect
 connect.mongo.hosts=localhost:27017
+

--- a/conf/mongodb-sink.properties
+++ b/conf/mongodb-sink.properties
@@ -18,6 +18,6 @@ name=mongo-sink-orders
 connector.class=com.datamountaineer.streamreactor.connect.mongodb.sink.MongoSinkConnector
 tasks.max=1
 topics=orders-topic
-connect.mongo.sink.kqcl=INSERT INTO orders SELECT * FROM orders-topic
+connect.mongo.sink.kcql=INSERT INTO orders SELECT * FROM orders-topic
 connect.mongo.database=connect
 connect.mongo.hosts=localhost:27017


### PR DESCRIPTION
The mongodb-sink.properties file contains a typo in the KCQL configuration parameter. Instead of connect.mongo.**kc**ql, connect.mongo.**kq**cl is used.  