### PR TITLE
influx: support string timestamp

### DIFF
--- a/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/StructFieldsExtractor.scala
+++ b/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/StructFieldsExtractor.scala
@@ -18,12 +18,14 @@ package com.datamountaineer.streamreactor.connect.influx
 
 import java.text.SimpleDateFormat
 import java.util.TimeZone
+import java.time.Instant
 
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import io.confluent.common.config.ConfigException
 import org.apache.kafka.connect.data._
 
 import scala.collection.JavaConversions._
+import scala.util.Try
 
 case class RecordData(timestamp: Long, fields: Seq[(String, Any)])
 
@@ -65,6 +67,7 @@ case class StructFieldsExtractor(includeAllFields: Boolean,
           case s: Short => s.toLong
           case i: Int => i.toLong
           case l: Long => l
+          case s: String => Try(Instant.parse(s).toEpochMilli).getOrElse(throw new IllegalArgumentException(s"${s} is not a valid format for timestamp"))
           case _ => throw new ConfigException(s"${timestampField.get} is not a valid field for the timestamp")
         }
       }.getOrElse(System.currentTimeMillis())

--- a/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/StructFieldsExtractor.scala
+++ b/kafka-connect-influxdb/src/main/scala/com/datamountaineer/streamreactor/connect/influx/StructFieldsExtractor.scala
@@ -67,7 +67,7 @@ case class StructFieldsExtractor(includeAllFields: Boolean,
           case s: Short => s.toLong
           case i: Int => i.toLong
           case l: Long => l
-          case s: String => Try(Instant.parse(s).toEpochMilli).getOrElse(throw new IllegalArgumentException(s"${s} is not a valid format for timestamp"))
+          case s: String => Try(Instant.parse(s).toEpochMilli).getOrElse(throw new IllegalArgumentException(s"${s} is not a valid format for timestamp, expected 'yyyy-MM-DDTHH:mm:ss.SSSZ'"))
           case _ => throw new ConfigException(s"${timestampField.get} is not a valid field for the timestamp")
         }
       }.getOrElse(System.currentTimeMillis())

--- a/kafka-connect-influxdb/src/test/scala/com/datamountaineer/streamreactor/connect/influx/StructFieldsExtractorTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/com/datamountaineer/streamreactor/connect/influx/StructFieldsExtractorTest.scala
@@ -84,13 +84,16 @@ class StructFieldsExtractorTest extends WordSpec with Matchers {
     "throw an exception if the timestamp field is a string and incorrect format" in {
       val schema = SchemaBuilder.struct().name("com.example.Person")
         .field("good", Schema.STRING_SCHEMA)
+        .field("millis", Schema.STRING_SCHEMA)
         .field("bad", Schema.STRING_SCHEMA).build()
 
       val struct = new Struct(schema)
         .put("good", "2017-01-01T00:00:00Z")
+        .put("millis", "2017-01-01T00:00:00.123Z")
         .put("bad", "not a time")
 
       StructFieldsExtractor(true, Map.empty, Some("good"), Set.empty).get(struct).timestamp shouldBe 1483228800000L
+      StructFieldsExtractor(true, Map.empty, Some("millis"), Set.empty).get(struct).timestamp shouldBe 1483228800123L
 
       intercept[IllegalArgumentException] {
         StructFieldsExtractor(true, Map.empty, Some("bad"), Set.empty).get(struct)

--- a/kafka-connect-influxdb/src/test/scala/com/datamountaineer/streamreactor/connect/influx/StructFieldsExtractorTest.scala
+++ b/kafka-connect-influxdb/src/test/scala/com/datamountaineer/streamreactor/connect/influx/StructFieldsExtractorTest.scala
@@ -61,7 +61,7 @@ class StructFieldsExtractorTest extends WordSpec with Matchers {
       }
     }
 
-    "throw an exception if the timestamp field is a string/double/float" in {
+    "throw an exception if the timestamp field is a double/float" in {
       val schema = SchemaBuilder.struct().name("com.example.Person")
         .field("abc", Schema.STRING_SCHEMA)
         .field("d", Schema.FLOAT64_SCHEMA)
@@ -73,15 +73,27 @@ class StructFieldsExtractorTest extends WordSpec with Matchers {
         .put("f", -5.93.toFloat)
 
       intercept[ConfigException] {
-        StructFieldsExtractor(true, Map.empty, Some("abc"), Set.empty).get(struct)
-      }
-
-      intercept[ConfigException] {
         StructFieldsExtractor(true, Map.empty, Some("d"), Set.empty).get(struct)
       }
 
       intercept[ConfigException] {
         StructFieldsExtractor(true, Map.empty, Some("f"), Set.empty).get(struct)
+      }
+    }
+
+    "throw an exception if the timestamp field is a string and incorrect format" in {
+      val schema = SchemaBuilder.struct().name("com.example.Person")
+        .field("good", Schema.STRING_SCHEMA)
+        .field("bad", Schema.STRING_SCHEMA).build()
+
+      val struct = new Struct(schema)
+        .put("good", "2017-01-01T00:00:00Z")
+        .put("bad", "not a time")
+
+      StructFieldsExtractor(true, Map.empty, Some("good"), Set.empty).get(struct).timestamp shouldBe 1483228800000L
+
+      intercept[IllegalArgumentException] {
+        StructFieldsExtractor(true, Map.empty, Some("bad"), Set.empty).get(struct)
       }
     }
 


### PR DESCRIPTION
This only supports `yyyy-MM-DDTHH:mm:ss.SSSZ` timestamps. It is a trivial addition, any reason not to include it originally?