### PR TITLE
fixed: high cpu on mqtt-source

### DIFF
--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfig.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfig.scala
@@ -67,10 +67,15 @@ object MqttConfig {
 }
 
 object MqttSourceConfig {
-  val config = MqttConfig.config //converter
+  val config = MqttConfig.config
+    //converter
     .define(MqttConfigConstants.THROW_ON_CONVERT_ERRORS_CONFIG, Type.BOOLEAN, MqttConfigConstants.THROW_ON_CONVERT_ERRORS_DEFAULT,
       Importance.HIGH, MqttConfigConstants.THROW_ON_CONVERT_ERRORS_DOC,
       "Converter", 1, ConfigDef.Width.MEDIUM, MqttConfigConstants.THROW_ON_CONVERT_ERRORS_DISPLAY)
+    //manager
+    .define(MqttConfigConstants.POLLING_TIMEOUT_CONFIG, Type.INT, MqttConfigConstants.POLLING_TIMEOUT_DEFAULT,
+      Importance.LOW, MqttConfigConstants.POLLING_TIMEOUT_DOC,
+      "Manager", 1, ConfigDef.Width.MEDIUM, MqttConfigConstants.POLLING_TIMEOUT_DISPLAY)
 
 }
 

--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfigConstants.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttConfigConstants.scala
@@ -59,6 +59,11 @@ object MqttConfigConstants {
   val CONNECTION_TIMEOUT_DISPLAY = "Connection timeout"
   val CONNECTION_TIMEOUT_DEFAULT = 3000
 
+  val POLLING_TIMEOUT_CONFIG = s"${CONNECTOR_PREFIX}.polling.timeout"
+  val POLLING_TIMEOUT_DOC = "Provides the timeout to poll incoming messages"
+  val POLLING_TIMEOUT_DISPLAY = "Polling timeout"
+  val POLLING_TIMEOUT_DEFAULT = 1000
+
   val CLEAN_SESSION_CONFIG = s"${CONNECTOR_PREFIX}.clean"
   val CLEAN_CONNECTION_DISPLAY = "Clean session"
   val CLEAN_CONNECTION_DEFAULT = true

--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttSourceSettings.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttSourceSettings.scala
@@ -32,6 +32,7 @@ case class MqttSourceSettings(connection: String,
                               kcql: Array[String],
                               mqttQualityOfService: Int,
                               connectionTimeout: Int,
+                              pollingTimeout: Int,
                               cleanSession: Boolean,
                               keepAliveInterval: Int,
                               sslCACertFile: Option[String],
@@ -46,6 +47,7 @@ case class MqttSourceSettings(connection: String,
     password.foreach(p => map.put(MqttConfigConstants.PASSWORD_CONFIG, p))
     map.put(MqttConfigConstants.CLIENT_ID_CONFIG, clientId)
     map.put(MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG, connectionTimeout.toString)
+    map.put(MqttConfigConstants.POLLING_TIMEOUT_CONFIG, pollingTimeout.toString)
     map.put(MqttConfigConstants.CLEAN_SESSION_CONFIG, cleanSession.toString)
     map.put(MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG, keepAliveInterval.toString)
     sslCACertFile.foreach(s => map.put(MqttConfigConstants.SSL_CA_CERT_CONFIG, s))
@@ -113,6 +115,7 @@ object MqttSourceSettings {
       kcqlStr,
       qs,
       config.getInt(MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG),
+      config.getInt(MqttConfigConstants.POLLING_TIMEOUT_CONFIG),
       config.getBoolean(MqttConfigConstants.CLEAN_SESSION_CONFIG),
       config.getInt(MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG),
       sslCACertFile,

--- a/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/source/MqttSourceTask.scala
+++ b/kafka-connect-mqtt/src/main/scala/com/datamountaineer/streamreactor/connect/mqtt/source/MqttSourceTask.scala
@@ -70,7 +70,7 @@ class MqttSourceTask extends SourceTask with StrictLogging {
       topic -> converter
     }
     logger.info("Starting Mqtt source...")
-    mqttManager = Some(new MqttManager(MqttClientConnectionFn.apply, convertersMap, settings.mqttQualityOfService, settings.kcql.map(Kcql.parse), settings.throwOnConversion))
+    mqttManager = Some(new MqttManager(MqttClientConnectionFn.apply, convertersMap, settings.mqttQualityOfService, settings.kcql.map(Kcql.parse), settings.throwOnConversion, settings.pollingTimeout))
     enableProgress = settings.enableProgress
   }
 

--- a/kafka-connect-mqtt/src/test/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttSourceSettingsTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/com/datamountaineer/streamreactor/connect/mqtt/config/MqttSourceSettingsTest.scala
@@ -35,6 +35,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
           MqttConfigConstants.CLEAN_SESSION_CONFIG -> "true",
           MqttConfigConstants.CLIENT_ID_CONFIG -> "someid",
           MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG -> "1000",
+          MqttConfigConstants.POLLING_TIMEOUT_CONFIG -> "500",
           MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG -> "1000",
           MqttConfigConstants.PASSWORD_CONFIG -> "somepassw",
           MqttConfigConstants.USER_CONFIG -> "user"
@@ -49,6 +50,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
       settings.user shouldBe Some("user")
       settings.keepAliveInterval shouldBe 1000
       settings.connectionTimeout shouldBe 1000
+      settings.pollingTimeout shouldBe 500
       settings.connection shouldBe "mqtt://localhost:61612?wireFormat.maxFrameSize=100000"
     }
 
@@ -62,6 +64,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
           MqttConfigConstants.CLEAN_SESSION_CONFIG -> "true",
           MqttConfigConstants.CLIENT_ID_CONFIG -> "someid",
           MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG -> "1000",
+          MqttConfigConstants.POLLING_TIMEOUT_CONFIG -> "500",
           MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG -> "1000",
           MqttConfigConstants.PASSWORD_CONFIG -> "somepassw",
           MqttConfigConstants.USER_CONFIG -> "user"
@@ -80,6 +83,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
           MqttConfigConstants.CLEAN_SESSION_CONFIG -> "true",
           MqttConfigConstants.CLIENT_ID_CONFIG -> "someid",
           MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG -> "1000",
+          MqttConfigConstants.POLLING_TIMEOUT_CONFIG -> "500",
           MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG -> "1000",
           MqttConfigConstants.PASSWORD_CONFIG -> "somepassw",
           MqttConfigConstants.USER_CONFIG -> "user"
@@ -98,6 +102,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
             MqttConfigConstants.CLEAN_SESSION_CONFIG -> "true",
             MqttConfigConstants.CLIENT_ID_CONFIG -> "someid",
             MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG -> "1000",
+            MqttConfigConstants.POLLING_TIMEOUT_CONFIG -> "500",
             MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG -> "1000",
             MqttConfigConstants.PASSWORD_CONFIG -> "somepassw",
             MqttConfigConstants.USER_CONFIG -> "user"
@@ -116,6 +121,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
             MqttConfigConstants.CLEAN_SESSION_CONFIG -> "true",
             MqttConfigConstants.CLIENT_ID_CONFIG -> "someid",
             MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG -> "1000",
+            MqttConfigConstants.POLLING_TIMEOUT_CONFIG -> "500",
             MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG -> "1000",
             MqttConfigConstants.PASSWORD_CONFIG -> "somepassw",
             MqttConfigConstants.USER_CONFIG -> "user"
@@ -133,6 +139,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
             MqttConfigConstants.CLEAN_SESSION_CONFIG -> "true",
             MqttConfigConstants.CLIENT_ID_CONFIG -> "someid",
             MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG -> "1000",
+            MqttConfigConstants.POLLING_TIMEOUT_CONFIG -> "500",
             MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG -> "1000",
             MqttConfigConstants.PASSWORD_CONFIG -> "somepassw",
             MqttConfigConstants.USER_CONFIG -> "user"
@@ -149,6 +156,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
           MqttConfigConstants.CLEAN_SESSION_CONFIG -> "true",
           MqttConfigConstants.CLIENT_ID_CONFIG -> "someid",
           MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG -> "1000",
+          MqttConfigConstants.POLLING_TIMEOUT_CONFIG -> "500",
           MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG -> "1000",
           MqttConfigConstants.PASSWORD_CONFIG -> "somepassw",
           MqttConfigConstants.USER_CONFIG -> "user"
@@ -165,6 +173,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
           MqttConfigConstants.CLEAN_SESSION_CONFIG -> "true",
           MqttConfigConstants.CLIENT_ID_CONFIG -> "someid",
           MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG -> "1000",
+          MqttConfigConstants.POLLING_TIMEOUT_CONFIG -> "500",
           MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG -> "1000",
           MqttConfigConstants.PASSWORD_CONFIG -> "somepassw",
           MqttConfigConstants.USER_CONFIG -> "user"
@@ -181,6 +190,7 @@ class MqttSourceSettingsTest extends WordSpec with Matchers {
           MqttConfigConstants.CLEAN_SESSION_CONFIG -> "true",
           MqttConfigConstants.CLIENT_ID_CONFIG -> "someid",
           MqttConfigConstants.CONNECTION_TIMEOUT_CONFIG -> "1000",
+          MqttConfigConstants.POLLING_TIMEOUT_CONFIG -> "500",
           MqttConfigConstants.KEEP_ALIVE_INTERVAL_CONFIG -> "1000",
           MqttConfigConstants.PASSWORD_CONFIG -> "somepassw",
           MqttConfigConstants.USER_CONFIG -> "user"

--- a/kafka-connect-mqtt/src/test/scala/com/datamountaineer/streamreactor/connect/mqtt/source/MqttManagerTest.scala
+++ b/kafka-connect-mqtt/src/test/scala/com/datamountaineer/streamreactor/connect/mqtt/source/MqttManagerTest.scala
@@ -47,6 +47,7 @@ class MqttManagerTest extends WordSpec with Matchers with BeforeAndAfter {
   val clientId = "MqttManagerTest"
   val qs = 1
   val connectionTimeout = 1000
+  val pollingTimeout = 500
   val keepAlive = 1000
 
   var mqttBroker: Option[Server] = None
@@ -103,6 +104,7 @@ class MqttManagerTest extends WordSpec with Matchers with BeforeAndAfter {
         Array(s"INSERT INTO $target SELECT * FROM $source"),
         qs,
         connectionTimeout,
+        pollingTimeout,
         true,
         keepAlive,
         None,
@@ -113,7 +115,8 @@ class MqttManagerTest extends WordSpec with Matchers with BeforeAndAfter {
         sourcesToConvMap,
         1,
         Array(Kcql.parse(s"INSERT INTO $target SELECT * FROM $source")),
-        true)
+        true,
+        settings.pollingTimeout)
 
       val messages = Seq("message1", "message2")
 
@@ -167,6 +170,7 @@ class MqttManagerTest extends WordSpec with Matchers with BeforeAndAfter {
         Array(s"INSERT INTO $target SELECT * FROM $source"),
         qs,
         connectionTimeout,
+        pollingTimeout,
         true,
         keepAlive,
         None,
@@ -177,7 +181,8 @@ class MqttManagerTest extends WordSpec with Matchers with BeforeAndAfter {
         sourcesToConvMap,
         1,
         Array(Kcql.parse(s"INSERT INTO $target SELECT * FROM $source")),
-        true)
+        true,
+        settings.pollingTimeout)
 
       val messages = Seq("message1", "message2")
       messages.foreach { m =>
@@ -244,6 +249,7 @@ class MqttManagerTest extends WordSpec with Matchers with BeforeAndAfter {
           s"INSERT INTO $target3 SELECT * FROM $source3"),
         qs,
         connectionTimeout,
+        pollingTimeout,
         cleanSession = true,
         keepAlive,
         None,
@@ -255,7 +261,8 @@ class MqttManagerTest extends WordSpec with Matchers with BeforeAndAfter {
         sourcesToConvMap,
         1,
         settings.kcql.map(Kcql.parse),
-        true)
+        true,
+        settings.pollingTimeout)
 
       val message1 = "message1".getBytes()
 


### PR DESCRIPTION
High CPU on MQTT source #267 

added configuration option: 'polling.timeout'