### PR TITLE
Issue 270 Support cassandra delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ target/
 /kafka-connect-coap/Californium.properties
 Californium.properties
 /gradle/wrapper/gradle-wrapper.properties
-/.DS_Store
+.DS_Store
 classes/*
 
 /kafka-connect-jms/*-*-*-*-*

--- a/kafka-connect-cassandra/build.gradle
+++ b/kafka-connect-cassandra/build.gradle
@@ -21,6 +21,7 @@ project(":kafka-connect-cassandra") {
         cassandraVersion = "2.2.6"
         cassandraUnitVersion = "3.1.3.2"
         jPountzVersion = "1.3.0"
+        jsonPathVersion = "2.4.0"
         snappyVersion = "1.1.2.1"
         smt = "0.1"
     }
@@ -38,6 +39,8 @@ project(":kafka-connect-cassandra") {
     dependencies {
 
         compile("com.datastax.cassandra:cassandra-driver-core:$cassandraDriverVersion")
+
+        compile("com.jayway.jsonpath:json-path:$jsonPathVersion")
 
         compile group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.0.33.Final', classifier: 'linux-x86_64'
 //        compile("com.landoop:kafka-connect-smt_2.11:$smt")

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -342,6 +342,15 @@ object CassandraConfigSink {
       1,
       ConfigDef.Width.MEDIUM,
       CassandraConfigConstants.DELETE_ROW_STATEMENT_DISPLAY)
+    .define(CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS,
+      Type.STRING,
+      CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS_DEFAULT,
+      Importance.LOW,
+      CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS_DOC,
+      "Mappings",
+      1,
+      ConfigDef.Width.MEDIUM,
+      CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS_DISPLAY)
 }
 
 case class CassandraConfigSink(props: util.Map[String, String])

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -324,6 +324,24 @@ object CassandraConfigSink {
       1,
       ConfigDef.Width.MEDIUM,
       CassandraConfigConstants.PROGRESS_COUNTER_ENABLED_DISPLAY)
+    .define(CassandraConfigConstants.DELETE_ROW_ENABLED,
+      Type.BOOLEAN,
+      CassandraConfigConstants.DELETE_ROW_ENABLED_DEFAULT,
+      Importance.LOW,
+      CassandraConfigConstants.DELETE_ROW_ENABLED_DOC,
+      "Mappings",
+      1,
+      ConfigDef.Width.MEDIUM,
+      CassandraConfigConstants.DELETE_ROW_ENABLED_DISPLAY)
+    .define(CassandraConfigConstants.DELETE_ROW_STATEMENT,
+      Type.STRING,
+      CassandraConfigConstants.DELETE_ROW_STATEMENT_DEFAULT,
+      Importance.LOW,
+      CassandraConfigConstants.DELETE_ROW_STATEMENT_DOC,
+      "Mappings",
+      1,
+      ConfigDef.Width.MEDIUM,
+      CassandraConfigConstants.DELETE_ROW_STATEMENT_DISPLAY)
 }
 
 case class CassandraConfigSink(props: util.Map[String, String])

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -343,7 +343,7 @@ object CassandraConfigSink {
       ConfigDef.Width.MEDIUM,
       CassandraConfigConstants.DELETE_ROW_STATEMENT_DISPLAY)
     .define(CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS,
-      Type.STRING,
+      Type.LIST,
       CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS_DEFAULT,
       Importance.LOW,
       CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS_DOC,

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -155,4 +155,18 @@ object CassandraConfigConstants {
   val PROGRESS_COUNTER_ENABLED_DOC = "Enables the output for how many records have been processed"
   val PROGRESS_COUNTER_ENABLED_DEFAULT = false
   val PROGRESS_COUNTER_ENABLED_DISPLAY = "Enable progress counter"
+  
+  val DELETE_ROW_PREFIX = "delete"
+  
+  val DELETE_ROW_ENABLED = s"$CONNECTOR_PREFIX.$DELETE_ROW_PREFIX.enabled"
+  val DELETE_ROW_ENABLED_DOC = "Enables row deletion from cassandra"
+  val DELETE_ROW_ENABLED_DEFAULT = false
+  val DELETE_ROW_ENABLED_DISPLAY = "Enable delete row"
+  
+  val DELETE_ROW_STATEMENT = s"$CONNECTOR_PREFIX.$DELETE_ROW_PREFIX.statement"
+  val DELETE_ROW_STATEMENT_DOC = "Delete statement for cassandra"
+  val DELETE_ROW_STATEMENT_DEFAULT = ""
+  val DELETE_ROW_STATEMENT_DISPLAY = "Enable delete row"
+  val DELETE_ROW_STATEMENT_MISSING = s"If $DELETE_ROW_ENABLED is true, $DELETE_ROW_STATEMENT is required."
+
 }

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -169,4 +169,9 @@ object CassandraConfigConstants {
   val DELETE_ROW_STATEMENT_DISPLAY = "Enable delete row"
   val DELETE_ROW_STATEMENT_MISSING = s"If $DELETE_ROW_ENABLED is true, $DELETE_ROW_STATEMENT is required."
 
+  val DELETE_ROW_STRUCT_FLDS = s"$CONNECTOR_PREFIX.$DELETE_ROW_PREFIX.struct_flds"
+  val DELETE_ROW_STRUCT_FLDS_DOC = s"Fields in the key struct data type used in there delete statement. Comma-separated in the order they are found in $DELETE_ROW_STATEMENT."
+  val DELETE_ROW_STRUCT_FLDS_DEFAULT = ""
+  val DELETE_ROW_STRUCT_FLDS_DISPLAY = "Field names in Key Struct"
+
 }

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -61,7 +61,11 @@ case class CassandraSinkSetting(keySpace: String,
                                 taskRetries: Int = CassandraConfigConstants.NBR_OF_RETIRES_DEFAULT,
                                 enableProgress: Boolean = CassandraConfigConstants.PROGRESS_COUNTER_ENABLED_DEFAULT,
                                 deleteEnabled: Boolean = CassandraConfigConstants.DELETE_ROW_ENABLED_DEFAULT,
-                                deleteStatement: String = CassandraConfigConstants.DELETE_ROW_STATEMENT_DEFAULT) extends CassandraSetting
+                                deleteStatement: String = CassandraConfigConstants.DELETE_ROW_STATEMENT_DEFAULT,
+                                deleteStructFields: String = CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS) extends CassandraSetting {
+
+  def structFlds: Seq[String] = deleteStructFields.split(",").map(s => s).toSeq
+}
 
 /**
   * Cassandra Setting used for both Readers and writers
@@ -128,6 +132,8 @@ object CassandraSettings extends StrictLogging {
     // validate
     if (deleteEnabled) require(deleteStmt.nonEmpty, CassandraConfigConstants.DELETE_ROW_STATEMENT_MISSING)
 
+    val structFlds = config.getString(CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS)
+
     CassandraSinkSetting(keySpace,
       kcqls,
       fields,
@@ -138,6 +144,7 @@ object CassandraSettings extends StrictLogging {
       retries,
       enableCounter,
       deleteEnabled,
-      deleteStmt)
+      deleteStmt,
+      structFlds)
   }
 }

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -62,10 +62,7 @@ case class CassandraSinkSetting(keySpace: String,
                                 enableProgress: Boolean = CassandraConfigConstants.PROGRESS_COUNTER_ENABLED_DEFAULT,
                                 deleteEnabled: Boolean = CassandraConfigConstants.DELETE_ROW_ENABLED_DEFAULT,
                                 deleteStatement: String = CassandraConfigConstants.DELETE_ROW_STATEMENT_DEFAULT,
-                                deleteStructFields: String = CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS) extends CassandraSetting {
-
-  def structFlds: Seq[String] = deleteStructFields.split(",").map(s => s).toSeq
-}
+                                deleteStructFields: Seq[String] = Seq.empty) extends CassandraSetting
 
 /**
   * Cassandra Setting used for both Readers and writers
@@ -132,7 +129,7 @@ object CassandraSettings extends StrictLogging {
     // validate
     if (deleteEnabled) require(deleteStmt.nonEmpty, CassandraConfigConstants.DELETE_ROW_STATEMENT_MISSING)
 
-    val structFlds = config.getString(CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS)
+    val structFlds = config.getList(CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS)
 
     CassandraSinkSetting(keySpace,
       kcqls,

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraSettings.scala
@@ -59,7 +59,9 @@ case class CassandraSinkSetting(keySpace: String,
                                 threadPoolSize: Int,
                                 consistencyLevel: Option[ConsistencyLevel],
                                 taskRetries: Int = CassandraConfigConstants.NBR_OF_RETIRES_DEFAULT,
-                                enableProgress: Boolean = CassandraConfigConstants.PROGRESS_COUNTER_ENABLED_DEFAULT) extends CassandraSetting
+                                enableProgress: Boolean = CassandraConfigConstants.PROGRESS_COUNTER_ENABLED_DEFAULT,
+                                deleteEnabled: Boolean = CassandraConfigConstants.DELETE_ROW_ENABLED_DEFAULT,
+                                deleteStatement: String = CassandraConfigConstants.DELETE_ROW_STATEMENT_DEFAULT) extends CassandraSetting
 
 /**
   * Cassandra Setting used for both Readers and writers
@@ -119,6 +121,13 @@ object CassandraSettings extends StrictLogging {
     val consistencyLevel = config.getConsistencyLevel
 
     val enableCounter = config.getBoolean(CassandraConfigConstants.PROGRESS_COUNTER_ENABLED)
+
+    // support for deletion
+    val deleteEnabled = config.getBoolean(CassandraConfigConstants.DELETE_ROW_ENABLED)
+    val deleteStmt = config.getString(CassandraConfigConstants.DELETE_ROW_STATEMENT)
+    // validate
+    if (deleteEnabled) require(deleteStmt.nonEmpty, CassandraConfigConstants.DELETE_ROW_STATEMENT_MISSING)
+
     CassandraSinkSetting(keySpace,
       kcqls,
       fields,
@@ -127,6 +136,8 @@ object CassandraSettings extends StrictLogging {
       threadPoolSize,
       consistencyLevel,
       retries,
-      enableCounter)
+      enableCounter,
+      deleteEnabled,
+      deleteStmt)
   }
 }

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/CassandraJsonWriter.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/CassandraJsonWriter.scala
@@ -57,7 +57,7 @@ class CassandraJsonWriter(connection: CassandraConnection, settings: CassandraSi
 
   private var deleteCache: Option[PreparedStatement] = cacheDeleteStatement
 
-  private val deleteStructFlds: Seq[String] = settings.structFlds
+  private val deleteStructFlds: Seq[String] = settings.deleteStructFields
 
   /**
     * Get a connection to cassandra based on the config

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
@@ -64,6 +64,8 @@ trait TestConfig extends StrictLogging with MockitoSugar {
   val TOPIC8 = "topic8"
   val TABLE9 = "table9"
   val TOPIC9 = "topic9"
+  val TABLE10 = "table10"
+  val TOPIC10 = "topic10"
 
   val TTL = 100000
 
@@ -140,6 +142,17 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
       CassandraConfigConstants.KCQL -> QUERY_SELECTION
+    ).asJava
+  }
+
+  def getCassandraConfigSinkPropsDeletePrimitive = {
+    Map(
+      CassandraConfigConstants.CONTACT_POINTS -> CONTACT_POINT,
+      CassandraConfigConstants.KEY_SPACE -> CASSANDRA_SINK_KEYSPACE,
+      CassandraConfigConstants.USERNAME -> USERNAME,
+      CassandraConfigConstants.PASSWD -> PASSWD,
+      CassandraConfigConstants.KCQL -> QUERY_SELECTION,
+      CassandraConfigConstants.DELETE_ROW_ENABLED -> "true"
     ).asJava
   }
 
@@ -293,7 +306,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       cluster.withSSL()
     }
 
-    val session = cluster.build().connect()
+     val session = cluster.build().connect()
     session.execute(s"DROP KEYSPACE IF EXISTS $keyspace")
     session.execute(s"CREATE KEYSPACE $keyspace WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 3}")
     session.execute(s"CREATE TABLE IF NOT EXISTS $keyspace.$TABLE1 (id text PRIMARY KEY, int_field int, long_field bigint," +
@@ -359,6 +372,13 @@ trait TestConfig extends StrictLogging with MockitoSugar {
          |timestamp_field timeuuid,
          |long_field bigint,
          |PRIMARY KEY(id,timestamp_field)) WITH CLUSTERING ORDER BY (timestamp_field asc)""".stripMargin)
+
+    session.execute(
+      s"""
+         |CREATE TABLE IF NOT EXISTS $keyspace.$TABLE10
+         |(id int,
+         |name text,
+         |PRIMARY KEY(id, name)) WITH CLUSTERING ORDER BY (name asc)""".stripMargin)
 
     session
   }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
@@ -66,6 +66,8 @@ trait TestConfig extends StrictLogging with MockitoSugar {
   val TOPIC9 = "topic9"
   val TABLE10 = "table10"
   val TOPIC10 = "topic10"
+  val TABLE11 = "table11"
+  val TOPIC11 = "topic11"
 
   val TTL = 100000
 
@@ -306,7 +308,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       cluster.withSSL()
     }
 
-     val session = cluster.build().connect()
+    val session = cluster.build().connect()
     session.execute(s"DROP KEYSPACE IF EXISTS $keyspace")
     session.execute(s"CREATE KEYSPACE $keyspace WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 3}")
     session.execute(s"CREATE TABLE IF NOT EXISTS $keyspace.$TABLE1 (id text PRIMARY KEY, int_field int, long_field bigint," +
@@ -379,6 +381,14 @@ trait TestConfig extends StrictLogging with MockitoSugar {
          |(id int,
          |name text,
          |PRIMARY KEY(id, name)) WITH CLUSTERING ORDER BY (name asc)""".stripMargin)
+
+    session.execute(
+      s"""
+         |CREATE TABLE IF NOT EXISTS $keyspace.$TABLE11
+         |(key1 int,
+         |key2 text,
+         |name text,
+         |PRIMARY KEY((key1, key2), name)) WITH CLUSTERING ORDER BY (name asc)""".stripMargin)
 
     session
   }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriter.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriter.scala
@@ -512,10 +512,15 @@ class TestCassandraJsonWriter extends WordSpec with Matchers with MockitoSugar w
     val insert = session.prepare(s"INSERT INTO $CASSANDRA_SINK_KEYSPACE.$TABLE11 (key1, key2, name) VALUES (?,?,?)").bind(key1, key2, name)
     session.execute(insert)
 
-    // TODO create the delete SinkRecord and scenario here...
-    case class KeyObject(key1: Int, key2: String)
+    val keySchema = SchemaBuilder.struct
+        .field("key1", Schema.INT32_SCHEMA)
+        .field("key2", Schema.STRING_SCHEMA)
+        .build
+    val keyStruct = new Struct(keySchema)
+    keyStruct.put("key1", key1)
+    keyStruct.put("key2", key2)
 
-    val record = new SinkRecord(TOPIC10, 0, SchemaBuilder.struct.build, KeyObject(key1, key2), null, null, 1)
+    val record = new SinkRecord(TOPIC10, 0, keySchema, keyStruct, null, null, 1)
     val context = mock[SinkTaskContext]
     val assignment = getAssignment
     when(context.assignment()).thenReturn(assignment)

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriter.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraJsonWriter.scala
@@ -467,7 +467,7 @@ class TestCassandraJsonWriter extends WordSpec with Matchers with MockitoSugar w
     }
   }
 
-  "Cassandra JSONWriter should handle deletion of records where keySchema is a primitive" in {
+  "Cassandra JSONWriter should handle deletion of records - Key isPrimitive, INT" in {
     val session = createTableAndKeySpace(CASSANDRA_SINK_KEYSPACE, secure = true, ssl = false)
 
     val idField = Int.box(UUIDs.timeBased().toString.hashCode)
@@ -501,7 +501,98 @@ class TestCassandraJsonWriter extends WordSpec with Matchers with MockitoSugar w
     (inserted.isEmpty) shouldBe true
   }
 
-  "Cassandra JSONWriter should handle deletion of records where key schema is a struct type" in {
+  "Cassandra JSONWriter should handle deletion of records - Key isPrimitive, STRING" in {
+    val session = createTableAndKeySpace(CASSANDRA_SINK_KEYSPACE, secure = true, ssl = false)
+
+    val uuid = UUIDs.timeBased()
+    val key1 = Int.box(uuid.hashCode)
+    val key2 = uuid.toString
+    val name = "Unit Test"
+
+    val insert = session.prepare(s"INSERT INTO $CASSANDRA_SINK_KEYSPACE.$TABLE11 (key1, key2, name) VALUES (?,?,?)").bind(key1, key2, name)
+    session.execute(insert)
+
+    val keySchema = SchemaBuilder.string().build
+    val keyValue =
+      s"""
+         | {
+         |   \"key1\": $key1,
+         |   \"key2\": \"$key2\"
+         | }
+       """.stripMargin
+
+    val record = new SinkRecord(TOPIC11, 0, keySchema, keyValue, null, null, 1)
+    val context = mock[SinkTaskContext]
+    val assignment = getAssignment
+    when(context.assignment()).thenReturn(assignment)
+
+    //get config
+    val props = Map(
+      CassandraConfigConstants.DELETE_ROW_STATEMENT -> s"delete from $CASSANDRA_SINK_KEYSPACE.$TABLE11 where key1 = ? AND key2 = ?",
+      CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS -> s"key1,key2").asJava ++
+      getCassandraConfigSinkPropsDeletePrimitive
+
+    val taskConfig = new CassandraConfigSink(props)
+
+    val writer = CassandraWriter(taskConfig, context)
+    writer.write(Seq(record))
+    Thread.sleep(1000)
+
+
+    val validate = session.prepare(s"SELECT * FROM $CASSANDRA_SINK_KEYSPACE.$TABLE11 WHERE key1 = ? AND key2 = ?").bind(key1, key2)
+    val result = session.execute(validate)
+
+    (result.isEmpty) shouldBe true
+  }
+
+  "Cassandra JSONWriter should handle deletion of records - Key isPrimitive, STRING with Complex Type" in {
+    val session = createTableAndKeySpace(CASSANDRA_SINK_KEYSPACE, secure = true, ssl = false)
+
+    val uuid = UUIDs.timeBased()
+    val key1 = uuid.hashCode
+    val key2 = uuid.toString
+    val name = "Unit Test"
+
+    val insert = session.prepare(s"INSERT INTO $CASSANDRA_SINK_KEYSPACE.$TABLE11 (key1, key2, name) VALUES (?,?,?)").bind(Int.box(key1), key2, name)
+    session.execute(insert)
+
+    val keySchema = SchemaBuilder.string().build
+    val keyValue =
+      s"""
+         | {
+         |   \"key1\": $key1,
+         |   \"nested\": {
+         |     \"key2\": \"$key2\"
+         |   }
+         | }
+       """.stripMargin
+
+    val record = new SinkRecord(TOPIC11, 0, keySchema, keyValue, null, null, 1)
+    val context = mock[SinkTaskContext]
+    val assignment = getAssignment
+    when(context.assignment()).thenReturn(assignment)
+
+    //get config
+    val props = Map(
+      CassandraConfigConstants.DELETE_ROW_STATEMENT -> s"delete from $CASSANDRA_SINK_KEYSPACE.$TABLE11 where key1 = ? AND key2 = ?",
+      CassandraConfigConstants.DELETE_ROW_STRUCT_FLDS -> s"key1,nested.key2").asJava ++
+      getCassandraConfigSinkPropsDeletePrimitive
+
+    val taskConfig = new CassandraConfigSink(props)
+
+    val writer = CassandraWriter(taskConfig, context)
+    writer.write(Seq(record))
+    Thread.sleep(1000)
+
+
+    val validate = session.prepare(s"SELECT * FROM $CASSANDRA_SINK_KEYSPACE.$TABLE11 WHERE key1 = ? AND key2 = ?").bind(Int.box(key1), key2)
+    val result = session.execute(validate)
+
+    (result.isEmpty) shouldBe true
+  }
+
+
+  "Cassandra JSONWriter should handle deletion of records - Key is STRUCT, flat" in {
     val session = createTableAndKeySpace(CASSANDRA_SINK_KEYSPACE, secure = true, ssl = false)
 
     val uuid = UUIDs.timeBased()
@@ -520,7 +611,7 @@ class TestCassandraJsonWriter extends WordSpec with Matchers with MockitoSugar w
     keyStruct.put("key1", key1)
     keyStruct.put("key2", key2)
 
-    val record = new SinkRecord(TOPIC10, 0, keySchema, keyStruct, null, null, 1)
+    val record = new SinkRecord(TOPIC11, 0, keySchema, keyStruct, null, null, 1)
     val context = mock[SinkTaskContext]
     val assignment = getAssignment
     when(context.assignment()).thenReturn(assignment)


### PR DESCRIPTION
See #270 

The use case of my company was to consume from a compacted topic and in cases where the message value is null, use the message key to delete the record from the cassandra table.

Please feel free to point me towards style and standards docs that I might have overlooked.