### PR TITLE
JMS source session not transacted so that client acking works.

### DIFF
--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
@@ -79,7 +79,7 @@ object JMSSessionProvider extends StrictLogging {
       case Some(user) => connectionFactory.createConnection(user, settings.password.get.value())
     }
 
-    val session = Try(connection.createSession(true, Session.CLIENT_ACKNOWLEDGE)) match {
+    val session = Try(connection.createSession(sink, Session.CLIENT_ACKNOWLEDGE)) match {
       case Success(s) =>
         logger.info("Created session")
         s

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSourceTaskTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSourceTaskTest.scala
@@ -40,7 +40,7 @@ class JMSSourceTaskTest extends TestBase with BeforeAndAfterAll {
   }
 
 
-  "should start a JMSSourceTask and read records" in {
+  "should start a JMSSourceTask, read records and ack messages" in {
     val broker = new BrokerService()
     broker.setPersistent(false)
     broker.setUseJmx(false)
@@ -76,6 +76,12 @@ class JMSSourceTaskTest extends TestBase with BeforeAndAfterAll {
     Thread.sleep(1000)
     val records = task.poll().asScala
     records.size shouldBe 10
+
+    val browser = session.createBrowser(queue, null)
+    val messagesLeft = browser.getEnumeration.asScala.size
+    browser.close()
+
+    messagesLeft shouldBe 0
 
     records.head.valueSchema().toString shouldBe JMSStructMessage.getSchema().toString
     task.stop()


### PR DESCRIPTION
Previously the JMS Source was set to use a transacted session which caused the acknowledge mode to be ignored.

Fixes #226 