### PR TITLE
JMS Acknowledge after messages have been processed by Kafka Connect

### DIFF
--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSourceTaskTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSSourceTaskTest.scala
@@ -77,6 +77,8 @@ class JMSSourceTaskTest extends TestBase with BeforeAndAfterAll {
     val records = task.poll().asScala
     records.size shouldBe 10
 
+    task.commit()
+
     val browser = session.createBrowser(queue, null)
     val messagesLeft = browser.getEnumeration.asScala.size
     browser.close()


### PR DESCRIPTION
This PR moves the acking of messages to the `commit` interface of a Kafka Connect `SourceTask`. From [here](https://docs.confluent.io/current/connect/devguide.html#task-example-source-task) it appears that acking in the `commit` will give us at-least-once semantics.