### PR TITLE
Cassandra Source: handle time zones when dealing w/ time slices

### DIFF
--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTask.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTask.scala
@@ -37,7 +37,6 @@ import scala.collection.JavaConverters._
   * Created by andrew@datamountaineer.com on 28/04/16.
   * stream-reactor
   */
-@DoNotDiscover
 class TestCassandraSourceTask extends WordSpec with Matchers with MockitoSugar with TestConfig
   with ConverterUtil {
 


### PR DESCRIPTION
Edits for the `bindAndFireTimebasedQuery` method to use java.time enhanced classes in Java 8 to handle timezones. This is related to the change addressed in issue #278 