### PR TITLE
JMS Message selector + Fix for message acking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,14 +70,14 @@ allprojects {
         slf4jVersion = "1.7.7"
         json4sVersion = "3.5.3"
         gsonVersion = "2.6.2"
-        KCQLVersion = "2.1.3"
+        KCQLVersion = "2.1.5"
         akkaVersion = "2.4.10"
         connectCLIVersion = "1.0.3"
 
 //        // The following 4 need to align to compile against a particular version
         confluentVersion = '3.3.0'
         kafkaVersion = '0.11.0.0'
-        dataMountaineerCommonVersion = "0.8.2.7"
+        dataMountaineerCommonVersion = "0.8.2.9"
         dataMountaineerTestKitVersion = "0.6"
 
 //        // Confluent 3.2

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/JMSSessionProvider.scala
@@ -89,36 +89,37 @@ object JMSSessionProvider extends StrictLogging {
     }
 
     val topicsConsumers = configureDestination(TopicDestination, context, session, settings, sink)
-                            .flatMap({ case (source, topic) => createConsumers(source, session, topic, settings.subscriptionName)}).toMap
+                            .flatMap({ case (source, ms, topic) => createConsumers(source, session, topic, settings.subscriptionName, ms)}).toMap
 
     val queueConsumers = configureDestination(QueueDestination, context, session, settings, sink)
-                            .flatMap({ case (source, queue) => createConsumers(source, session, queue, settings.subscriptionName) }).toMap
+                            .flatMap({ case (source, ms, queue) => createConsumers(source, session, queue, settings.subscriptionName, ms) }).toMap
 
 
     val topicProducers = configureDestination(TopicDestination, context, session, settings, sink)
-                            .flatMap({ case (source, topic) => createProducers(source, session, topic) }).toMap
+                            .flatMap({ case (source, _, topic) => createProducers(source, session, topic) }).toMap
 
     val queueProducers = configureDestination(QueueDestination, context, session, settings, sink)
-                            .flatMap({ case (source, queue) => createProducers(source, session, queue) }).toMap
+                            .flatMap({ case (source, _, queue) => createProducers(source, session, queue) }).toMap
 
     new JMSSessionProvider(queueConsumers, topicsConsumers, queueProducers, topicProducers, session, connection, context)
   }
 
-  def configureDestination(destinationType: DestinationType, context: InitialContext, session: Session, settings: JMSSettings, sink: Boolean = false): List[(String, Destination)] = {
+  def configureDestination(destinationType: DestinationType, context: InitialContext, session: Session, settings: JMSSettings, sink: Boolean = false): List[(String, Option[String], Destination)] = {
     settings.settings
       .filter(f => f.destinationType.equals(destinationType))
-      .map(t => (t.source, getDestination(if (sink) t.target else t.source, context, settings.destinationSelector, destinationType, session)))
+      .map(t => (t.source, t.messageSelector, getDestination(if (sink) t.target else t.source, context, settings.destinationSelector, destinationType, session)))
   }
 
   def createProducers(source: String, session: Session, destination: Destination) = Map(source -> session.createProducer(destination))
 
-  def createConsumers(source: String, session: Session, destination: Destination, subscriptionName: Option[String]) = Map(source -> {
+  def createConsumers(source: String, session: Session, destination: Destination, subscriptionName: Option[String], messageSelector: Option[String]) = Map(source -> {
+    val selector = messageSelector.getOrElse(null)
     subscriptionName match {
-      case None =>  session.createConsumer(destination)
+      case None => session.createConsumer(destination, selector)
       case Some(name) => 
         destination match {
-          case destination: Topic => session.createSharedDurableConsumer(destination, name)
-          case _ => session.createConsumer(destination)
+          case destination: Topic => session.createSharedDurableConsumer(destination, name, selector)
+          case _ => session.createConsumer(destination, selector)
         }
     }
   })

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSSettings.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/config/JMSSettings.scala
@@ -33,8 +33,8 @@ case class JMSSetting(source: String,
                       ignoreField: Set[String],
                       destinationType: DestinationType,
                       format: FormatType = FormatType.JSON,
-                      sourceConverters: Option[Converter]
-                     )
+                      sourceConverters: Option[Converter],
+                      messageSelector: Option[String])
 
 case class JMSSettings(connectionURL: String,
                        initialContextClass: String,
@@ -145,7 +145,8 @@ object JMSSettings extends StrictLogging {
                 ignoreFields(r.getSource),
                 getDestinationType(jmsName, jmsQueues, jmsTopics),
                 getFormatType(r),
-                converter)
+                converter,
+                Option(r.getWithJmsSelector()))
     }).toList
 
     new JMSSettings(

--- a/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/JMSSourceTask.scala
+++ b/kafka-connect-jms/src/main/scala/com/datamountaineer/streamreactor/connect/jms/source/JMSSourceTask.scala
@@ -61,7 +61,7 @@ class JMSSourceTask extends SourceTask with StrictLogging {
       records = collection.mutable.Seq(polled.map({ case (_, record) => record }).toSeq: _*)
       messages = collection.mutable.Seq(polled.map({ case (message, _) => message }).toSeq: _*)
     } finally {
-      ackMessage = messages.headOption
+      if(messages.size > 0) ackMessage = messages.headOption
     }
 
     if (enableProgress) {

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/TestBase.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/TestBase.scala
@@ -47,9 +47,11 @@ trait TestBase extends WordSpec with Matchers with MockitoSugar {
   val KCQL_SOURCE_QUEUE = s"INSERT INTO $TOPIC1 SELECT * FROM $QUEUE1 WITHTYPE QUEUE"
   val KCQL_SINK_QUEUE = s"INSERT INTO $QUEUE1 SELECT * FROM $TOPIC2 WITHTYPE QUEUE"
   val KCQL_SOURCE_TOPIC = s"INSERT INTO $TOPIC1 SELECT * FROM $TOPIC1 WITHTYPE TOPIC"
-  val KCQL_SINK_TOPIC = s"INSERT INTO $TOPIC1 SELECT * FROM $TOPIC1  WITHTYPE TOPIC"
+  val KCQL_SINK_TOPIC = s"INSERT INTO $TOPIC1 SELECT * FROM $TOPIC1 WITHTYPE TOPIC"
   val KCQL_MIX = s"$KCQL_SOURCE_QUEUE;$KCQL_SOURCE_TOPIC"
   val KCQL_MIX_SINK = s"$KCQL_SINK_QUEUE;$KCQL_SINK_TOPIC"
+  val MESSAGE_SELECTOR = "a > b"
+  val KCQL_SOURCE_TOPIC_WITH_JMS_SELECTOR = kcqlWithMessageSelector(MESSAGE_SELECTOR)
   val JMS_USER = ""
   val JMS_PASSWORD = ""
   val CONNECTION_FACTORY = "ConnectionFactory"
@@ -60,8 +62,8 @@ trait TestBase extends WordSpec with Matchers with MockitoSugar {
   val TOPIC_LIST = TOPIC1
   val SELECTOR = DestinationSelector.CDI.toString
   val AVRO_QUEUE = "avro_queue"
-  val QUEUE_CONVERTER = s"com.datamountaineer.streamreactor.connect.converters.source.AvroConverter"
-  val KCQL_AVRO_SOURCE = s"INSERT INTO $TOPIC1 SELECT * FROM $AVRO_QUEUE WITHCONVERTER=$QUEUE_CONVERTER WITHTYPE QUEUE"
+  val QUEUE_CONVERTER = s"`com.datamountaineer.streamreactor.connect.converters.source.AvroConverter`"
+  val KCQL_AVRO_SOURCE = s"INSERT INTO $TOPIC1 SELECT * FROM $AVRO_QUEUE WITHTYPE QUEUE WITHCONVERTER=$QUEUE_CONVERTER"
   val KCQL_AVRO_SOURCE_MIX = s"$KCQL_AVRO_SOURCE;$KCQL_SOURCE_TOPIC"
 
   val AVRO_FILE = getSchemaFile()
@@ -107,6 +109,12 @@ trait TestBase extends WordSpec with Matchers with MockitoSugar {
       JMSConfigConstants.JMS_URL -> JMS_URL
     ).asJava
   }
+
+  def getProps1TopicWithMessageSelector(url: String = JMS_URL, msgSelector: String = MESSAGE_SELECTOR) = {
+    getProps1Topic.asScala ++
+      Map(JMSConfigConstants.KCQL -> kcqlWithMessageSelector(msgSelector),
+        JMSConfigConstants.JMS_URL -> url)
+  }.asJava
 
   def getProps1TopicJNDI = {
     Map(JMSConfigConstants.KCQL -> KCQL_SOURCE_TOPIC,
@@ -258,4 +266,7 @@ trait TestBase extends WordSpec with Matchers with MockitoSugar {
     output.close()
     baos.toByteArray
   }
+
+  def kcqlWithMessageSelector(msgSelector: String) =
+    s"INSERT INTO $TOPIC1 SELECT * FROM $JMS_TOPIC1 WITHTYPE TOPIC WITHJMSSELECTOR=`$msgSelector`"
  }

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/config/JMSSettingsTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/config/JMSSettingsTest.scala
@@ -41,6 +41,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll {
     setting.target shouldBe TOPIC1
     setting.sourceConverters shouldBe None
     setting.destinationType shouldBe QueueDestination
+    setting.messageSelector shouldBe None
     settings.connectionURL shouldBe JMS_URL
   }
 
@@ -53,6 +54,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll {
     setting.target shouldBe TOPIC1
     setting.sourceConverters shouldBe None
     setting.destinationType shouldBe TopicDestination
+    setting.messageSelector shouldBe None
     settings.connectionURL shouldBe JMS_URL
   }
 
@@ -65,6 +67,7 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll {
     setting.target shouldBe TOPIC1
     setting.sourceConverters shouldBe None
     setting.destinationType shouldBe TopicDestination
+    setting.messageSelector shouldBe None
     settings.destinationSelector shouldBe DestinationSelector.JNDI
     settings.connectionURL shouldBe JMS_URL
   }
@@ -78,12 +81,14 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll {
     queue.target shouldBe TOPIC1
     queue.sourceConverters shouldBe None
     queue.destinationType shouldBe QueueDestination
+    queue.messageSelector shouldBe None
 
     val topic = settings.settings.last
     topic.source shouldBe TOPIC1
     topic.target shouldBe TOPIC1
     topic.sourceConverters shouldBe None
     topic.destinationType shouldBe TopicDestination
+    topic.messageSelector shouldBe None
 
     settings.destinationSelector shouldBe DestinationSelector.JNDI
     settings.connectionURL shouldBe JMS_URL
@@ -98,12 +103,14 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll {
     queue.target shouldBe TOPIC1
     queue.sourceConverters.get.isInstanceOf[AvroConverter] shouldBe true
     queue.destinationType shouldBe QueueDestination
+    queue.messageSelector shouldBe None
 
     val topic = settings.settings.last
     topic.source shouldBe TOPIC1
     topic.target shouldBe TOPIC1
     topic.destinationType shouldBe TopicDestination
     topic.sourceConverters.getOrElse(None) shouldBe None
+    topic.messageSelector shouldBe None
 
     settings.destinationSelector shouldBe DestinationSelector.CDI
     settings.connectionURL shouldBe JMS_URL
@@ -117,11 +124,29 @@ class JMSSettingsTest extends TestBase with BeforeAndAfterAll {
     queue.source shouldBe TOPIC2
     queue.target shouldBe QUEUE1
     queue.sourceConverters shouldBe None
+    queue.messageSelector shouldBe None
 
     val topic = settings.settings.last
     topic.source shouldBe TOPIC1
     topic.target shouldBe TOPIC1
     topic.destinationType shouldBe TopicDestination
+    topic.messageSelector shouldBe None
+
+    settings.destinationSelector shouldBe DestinationSelector.CDI
+    settings.connectionURL shouldBe JMS_URL
+  }
+
+  "should create a JMSSettings for a source with only 1 topic with a message selector" in {
+    val props = getProps1TopicWithMessageSelector()
+    val config = JMSConfig(props)
+    val settings = JMSSettings(config, false)
+
+    val topic = settings.settings.head
+    topic.source shouldBe TOPIC1
+    topic.target shouldBe TOPIC1
+    topic.sourceConverters shouldBe None
+    topic.destinationType shouldBe TopicDestination
+    topic.messageSelector shouldBe Some(MESSAGE_SELECTOR)
 
     settings.destinationSelector shouldBe DestinationSelector.CDI
     settings.connectionURL shouldBe JMS_URL

--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSReaderTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSReaderTest.scala
@@ -17,7 +17,7 @@
 package com.datamountaineer.streamreactor.connect.source
 
 import java.io.File
-import javax.jms.Session
+import javax.jms.{Connection, Session}
 
 import com.datamountaineer.streamreactor.connect.TestBase
 import com.datamountaineer.streamreactor.connect.jms.config.{JMSConfig, JMSSettings}
@@ -27,6 +27,7 @@ import org.apache.activemq.ActiveMQConnectionFactory
 import org.apache.activemq.broker.BrokerService
 import org.apache.kafka.connect.data.Struct
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
 
 import scala.reflect.io.Path
 
@@ -34,31 +35,16 @@ import scala.reflect.io.Path
   * Created by andrew@datamountaineer.com on 20/03/2017. 
   * stream-reactor
   */
-class JMSReaderTest extends TestBase with BeforeAndAfterAll {
+class JMSReaderTest extends TestBase with BeforeAndAfterAll with Eventually {
 
   override def afterAll(): Unit = {
     Path(AVRO_FILE).delete()
   }
 
-  "should read message from JMS queue without converters" in {
-    val broker = new BrokerService()
-    broker.setPersistent(false)
-    broker.setUseJmx(false)
-    broker.setDeleteAllMessagesOnStartup(true)
-    val brokerUrl = "tcp://localhost:61630"
-    broker.addConnector(brokerUrl)
-    broker.setUseShutdownHook(false)
-    val property = "java.io.tmpdir"
-    val tempDir = System.getProperty(property)
-    broker.setDataDirectoryFile( new File(tempDir))
-    broker.setTmpDataDirectory( new File(tempDir))
+  "should read message from JMS queue without converters" in testWithBrokerOnPort(61631) { (conn, brokerUrl) =>
+
     val messageCount = 9
 
-    broker.start()
-    val connectionFactory = new ActiveMQConnectionFactory()
-    connectionFactory.setBrokerURL(brokerUrl)
-    val conn = connectionFactory.createConnection()
-    conn.start()
     val session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE)
     val queue = session.createQueue(QUEUE1)
     val queueProducer = session.createProducer(queue)
@@ -70,31 +56,17 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll {
     val settings = JMSSettings(config, false)
     val reader = JMSReader(settings)
 
-    val messagesRead = reader.poll()
-    messagesRead.size shouldBe messageCount
-    messagesRead.head._2.valueSchema().toString shouldBe JMSStructMessage.getSchema().toString
+    eventually {
+      val messagesRead = reader.poll()
+      messagesRead.size shouldBe messageCount
+      messagesRead.head._2.valueSchema().toString shouldBe JMSStructMessage.getSchema().toString
+    }
   }
 
-  "should read and convert to avro" in {
+  "should read and convert to avro" in testWithBrokerOnPort(61632) { (conn, brokerUrl) =>
 
-    val broker = new BrokerService()
-    broker.setPersistent(false)
-    broker.setUseJmx(false)
-    broker.setDeleteAllMessagesOnStartup(true)
-    val brokerUrl = "tcp://localhost:61631"
-    broker.addConnector(brokerUrl)
-    broker.setUseShutdownHook(false)
-    val property = "java.io.tmpdir"
-    val tempDir = System.getProperty(property)
-    broker.setDataDirectoryFile( new File(tempDir))
-    broker.setTmpDataDirectory( new File(tempDir))
     val messageCount = 10
 
-    broker.start()
-    val connectionFactory = new ActiveMQConnectionFactory()
-    connectionFactory.setBrokerURL(brokerUrl)
-    val conn = connectionFactory.createConnection()
-    conn.start()
     val session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE)
     val avro = session.createQueue(AVRO_QUEUE)
     val avroProducer = session.createProducer(avro)
@@ -106,12 +78,69 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll {
     val settings = JMSSettings(config, false)
     val reader = JMSReader(settings)
 
-    val messagesRead = reader.poll().toVector
-    messagesRead.nonEmpty shouldBe true
-    val sourceRecord = messagesRead.head._2
+    eventually {
+      val messagesRead = reader.poll().toVector
+      messagesRead.nonEmpty shouldBe true
+      val sourceRecord = messagesRead.head._2
+      sourceRecord.value().isInstanceOf[Struct] shouldBe true
+      val struct = sourceRecord.value().asInstanceOf[Struct]
+      struct.getString("name") shouldBe "andrew"
+    }
+  }
 
-    sourceRecord.value().isInstanceOf[Struct] shouldBe true
-    val struct = sourceRecord.value().asInstanceOf[Struct]
-    struct.getString("name") shouldBe "andrew"
+  "should read messages from JMS queue with message selector" in testWithBrokerOnPort(61633) { (conn, brokerUrl) =>
+    val messageCount = 10
+
+    val session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE)
+    val topic = session.createTopic(TOPIC1)
+    val topicProducer = session.createProducer(topic)
+
+    val messages = getTextMessages(messageCount / 2, session).map { m =>
+      m.setStringProperty("Fruit", "apples")
+      m
+    } ++ getTextMessages(messageCount / 2, session).map { m =>
+      m.setStringProperty("Fruit", "pears")
+      m
+    }
+
+    val messageSelector = "Fruit='apples'"
+
+    val props = getProps1TopicWithMessageSelector(brokerUrl, messageSelector)
+    val config = JMSConfig(props)
+    val settings = JMSSettings(config, false)
+    val reader = JMSReader(settings)
+
+    messages.foreach(m => topicProducer.send(m))
+
+    eventually {
+      val messagesRead = reader.poll()
+      messagesRead.size shouldBe messageCount / 2
+      messagesRead.keySet.foreach { msg =>
+        msg.getStringProperty("Fruit") shouldBe "apples"
+      }
+      messagesRead.head._2.valueSchema().toString shouldBe JMSStructMessage.getSchema().toString
+    }
+  }
+
+  def testWithBrokerOnPort(port: Int)(test: (Connection, String) => Unit) = {
+    val broker = new BrokerService()
+    broker.setPersistent(false)
+    broker.setUseJmx(false)
+    broker.setDeleteAllMessagesOnStartup(true)
+    val brokerUrl = s"tcp://localhost:$port"
+    broker.addConnector(brokerUrl)
+    broker.setUseShutdownHook(false)
+    val property = "java.io.tmpdir"
+    val tempDir = System.getProperty(property)
+    broker.setDataDirectoryFile( new File(tempDir))
+    broker.setTmpDataDirectory( new File(tempDir))
+    broker.start()
+
+    val connectionFactory = new ActiveMQConnectionFactory()
+    connectionFactory.setBrokerURL(brokerUrl)
+    val conn = connectionFactory.createConnection()
+    conn.start()
+
+    test(conn, brokerUrl)
   }
 }


### PR DESCRIPTION
This PR introduces allowing for message selectors in the JMS connector consumers. 

There is also a fix for the message acking, it was only working if messages had been polled in the previous loop before a commit.