### PR TITLE
Use a map to represent the properties field in the jms avro schema

### DIFF
--- a/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSReaderTest.scala
+++ b/kafka-connect-jms/src/test/scala/com/datamountaineer/streamreactor/connect/source/JMSReaderTest.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.connect.data.Struct
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 
+import scala.collection.JavaConverters._
 import scala.reflect.io.Path
 
 /**
@@ -118,7 +119,13 @@ class JMSReaderTest extends TestBase with BeforeAndAfterAll with Eventually {
       messagesRead.keySet.foreach { msg =>
         msg.getStringProperty("Fruit") shouldBe "apples"
       }
-      messagesRead.head._2.valueSchema().toString shouldBe JMSStructMessage.getSchema().toString
+
+      val sourceRecord = messagesRead.head._2
+      sourceRecord.valueSchema().toString shouldBe JMSStructMessage.getSchema().toString
+      sourceRecord.value().isInstanceOf[Struct] shouldBe true
+
+      val struct = sourceRecord.value().asInstanceOf[Struct]
+      struct.getMap("properties").asScala shouldBe Map("Fruit" -> "apples")
     }
   }
 


### PR DESCRIPTION
An optional array where each element has an optional key and an optional value seems to make more sense as an optional Map. 

Could even make the map empty if there are no properties instead of making the Map optional - not entirely sure of the consequences of that though for users of the schema. 

What do you guys think?