### PR TITLE
FIX: eliminate "deadlock" in Cassandra Source querying

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraSourceTask.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraSourceTask.scala
@@ -129,19 +129,19 @@ class CassandraSourceTask extends SourceTask with StrictLogging {
     val queue = queues(tableName)
     
     logger.info(s"@ start of poll cycle the queue size for $tableName is: ${queue.size}")
-    
+
     // minimized the changes but still fix #300
     // depending on buffer size, batch size, and volume of data coming in
-    // we could lots of data on the internal queue coming off slower
+    // we could see data on the internal queue coming off slower
     // than we are putting data into it
-    
-    // if we are in the middle of working 
-    // on data from the last polling cycle
-    // we will not attempt to get more data
+
     if (!reader.isQuerying) {
       // start another query 
       reader.read
     } else {
+      // if we are in the middle of working 
+      // on data from the last polling cycle
+      // we will not attempt to get more data
       logger.info(s"Reader for table $tableName is still querying...")
     }
     
@@ -153,24 +153,6 @@ class CassandraSourceTask extends SourceTask with StrictLogging {
     } else {
       List[SourceRecord]()
     }
-    
-
-    
-
-//    val records = if (!reader.isQuerying) {
-//      //query
-//      reader.read()
-//      if (!queue.isEmpty) {
-//        logger.debug(s"Attempting to drain $batchSize items from the queue for table $tableName")
-//        val records = QueueHelpers.drainQueue(queue, batchSize.get).toList
-//        records
-//      } else {
-//        List[SourceRecord]()
-//      }
-//    } else {
-//      logger.info(s"Reader for table $tableName is still querying...")
-//      List[SourceRecord]()
-//    }
     
     logger.info(s"@ end of poll cycle the queue size for $tableName is: ${queue.size}")
     

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraSourceTask.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraSourceTask.scala
@@ -127,21 +127,54 @@ class CassandraSourceTask extends SourceTask with StrictLogging {
   def process(tableName: String): List[SourceRecord] = {
     val reader = readers(tableName)
     val queue = queues(tableName)
-    logger.info(s"the queue size for $tableName is: ${queue.size}")
+    
+    logger.info(s"@ start of poll cycle the queue size for $tableName is: ${queue.size}")
+    
+    // minimized the changes but still fix #300
+    // depending on buffer size, batch size, and volume of data coming in
+    // we could lots of data on the internal queue coming off slower
+    // than we are putting data into it
+    
+    // if we are in the middle of working 
+    // on data from the last polling cycle
+    // we will not attempt to get more data
     if (!reader.isQuerying) {
-      //query
-      reader.read()
-      if (!queue.isEmpty) {
-        logger.debug(s"Attempting to drain $batchSize items from the queue for table $tableName")
-        val records = QueueHelpers.drainQueue(queue, batchSize.get).toList
-        records
-      } else {
-        List[SourceRecord]()
-      }
+      // start another query 
+      reader.read
     } else {
-      logger.info(s"Reader for table $tableName is still querying")
+      logger.info(s"Reader for table $tableName is still querying...")
+    }
+    
+    // let's make some of the data on the queue 
+    // available for publishing to Kafka
+    val records = if (!queue.isEmpty) {
+      logger.info(s"Attempting to drain $batchSize items from the queue for table $tableName")
+      QueueHelpers.drainQueue(queue, batchSize.get).toList
+    } else {
       List[SourceRecord]()
     }
+    
+
+    
+
+//    val records = if (!reader.isQuerying) {
+//      //query
+//      reader.read()
+//      if (!queue.isEmpty) {
+//        logger.debug(s"Attempting to drain $batchSize items from the queue for table $tableName")
+//        val records = QueueHelpers.drainQueue(queue, batchSize.get).toList
+//        records
+//      } else {
+//        List[SourceRecord]()
+//      }
+//    } else {
+//      logger.info(s"Reader for table $tableName is still querying...")
+//      List[SourceRecord]()
+//    }
+    
+    logger.info(s"@ end of poll cycle the queue size for $tableName is: ${queue.size}")
+    
+    records
   }
 
   /**

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraTableReader.scala
@@ -229,8 +229,7 @@ class CassandraTableReader(private val session: Session,
               } else {
                 getTimebasedMaxOffsetForRow(maxOffset, row)
               }
-// TODO: set logger back to debug              
-              logger.info(s"Max Offset is currently: ${maxOffset.get}")
+              logger.debug(s"Max Offset is currently: ${maxOffset.get}")
             }
             processRow(row)
             counter += 1
@@ -305,8 +304,7 @@ class CassandraTableReader(private val session: Session,
       val rowOffset: Date = if (bulk) dateFormatter.parse(tableOffset.get) else extractTimestamp(row)
       dateFormatter.format(rowOffset)
     }
-//TODO: set the logger to debug    
-    logger.info(s"processing row with offset: $offset")
+    logger.debug(s"processing row with offset: $offset")
 
     // create source record
     val record = if (config.isUnwrapping) {
@@ -321,8 +319,6 @@ class CassandraTableReader(private val session: Session,
 
     // add source record to queue
     while (!queue.offer(record, 1, TimeUnit.SECONDS)) {
-// TODO: remove logging statement
-      logger.info(s"adding the record with offset ($offset) to the queue...")
     }
   }
 
@@ -360,11 +356,9 @@ class CassandraTableReader(private val session: Session,
   private def reset(offset: Option[String]) = {
     //set the offset to the 'now' bind value
     val table = config.getTarget
-// TODO: change back to debug
-    logger.info(s"Setting offset for $keySpace.$table to $offset.")
+    logger.debug(s"Setting offset for $keySpace.$table to $offset.")
     tableOffset = offset.orElse(tableOffset)
     //switch to not querying
-// TODO: change back to debug    
     logger.info(s"Setting querying for $keySpace.$table to false.")
     querying.set(false)
   }


### PR DESCRIPTION
This is a proposed fix for #300 
Have tested it in our QA environment with 
- 40,000 per min
- poll interval = 1 sec
- batch size = 1000
- time slice = 10 sec (hard coded at the moment) 

From the logs you can still see that the internal queue grows from time to time but this seems to keep good steady flow. 